### PR TITLE
Fix corrupted kvstorage file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 
 install:
   # Install gox
-  - go get github.com/gz-c/gox
+  - go get github.com/mitchellh/gox
   # Install dependences for building wallet
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PULL_REQUEST" == false ]]; then sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils libudev-dev libusb-1.0-0-dev; fi
   - if [[ ! -d $GOPATH/src/github.com/SkycoinProject/skycoin ]]; then mkdir -p $GOPATH/src/github.com/SkycoinProject; ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/SkycoinProject/skycoin; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Fix issue #7 #162, corrupted file in ~/.skycoin/data/ dir makes the desktop wallet show ERROR #1.
 - Fix issue #87, can not run web gui from skycoin docker image.
 - Do windows electron builds by travis and abandon the appveyor
 - Migrate `skycoin.net` to `skycoin.com`


### PR DESCRIPTION
Fixes #7 #162

Changes:
- When loading kvstorage file failed due to the corrupted file, then backup it and create a new empty file. 
- Add unit tests

Does this change need to mentioned in CHANGELOG.md?
Yes.
