### PR TITLE
Fix inconsistent wallet state after saving failed

### DIFF
--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -1847,6 +1847,19 @@ func TestWalletNewAddressesHandler(t *testing.T) {
 			gatewayNewAddressesErr: wallet.ErrInvalidPassword,
 		},
 		{
+			name:   "400 Bad Request - permission denied",
+			method: http.MethodPost,
+			body: &httpBody{
+				ID:  "foo",
+				Num: "1",
+			},
+			status:                 http.StatusBadRequest,
+			err:                    "400 Bad Request - saving wallet permission denied",
+			walletID:               "foo",
+			n:                      1,
+			gatewayNewAddressesErr: wallet.ErrWalletPermission,
+		},
+		{
 			name:   "200 - OK",
 			method: http.MethodPost,
 			body: &httpBody{

--- a/src/util/file/file.go
+++ b/src/util/file/file.go
@@ -307,3 +307,9 @@ func Exists(fn string) (bool, error) {
 	}
 	return true, nil
 }
+
+// IsWritable checks if the file is writable
+func IsWritable(fn string) bool {
+	st, _ := os.Stat(fn)
+	return (st.Mode().Perm()&(1<<uint(7)) == 0)
+}

--- a/src/util/file/file_test.go
+++ b/src/util/file/file_test.go
@@ -46,7 +46,7 @@ func requireIsRegularFile(t *testing.T, filename string) {
 
 func cleanup(fn string) {
 	paths := []string{fn}
-	filepath.Walk("./", func(path string, info os.FileInfo, err error) error {
+	filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			panic(err)
 		}

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -293,6 +293,7 @@ func (serv *Service) NewAddresses(wltID string, password []byte, num uint64) ([]
 	// Save the wallet first
 	if err := Save(w, serv.config.WalletDir); err != nil {
 		if os.IsPermission(err) {
+			logger.WithError(err).Warning("Create new addresses failed")
 			return nil, ErrWalletPermission
 		}
 		return nil, err

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -3,12 +3,14 @@ package wallet
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/SkycoinProject/skycoin/src/cipher"
 	"github.com/SkycoinProject/skycoin/src/cipher/bip44"
+	"github.com/SkycoinProject/skycoin/src/util/file"
 )
 
 // TransactionsFinder interface for finding address related transaction hashes
@@ -288,6 +290,17 @@ func (serv *Service) NewAddresses(wltID string, password []byte, num uint64) ([]
 		if err := f(w); err != nil {
 			return nil, err
 		}
+	}
+
+	// Check if the target wallet is writeable.
+	wltPath := filepath.Join(serv.config.WalletDir, w.Filename())
+	exist, err := file.Exists(wltPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if exist && file.IsWritable(wltPath) {
+		return nil, fmt.Errorf("Wallet %s is not writable", wltPath)
 	}
 
 	// Save the wallet first

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -3,12 +3,14 @@ package wallet
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/SkycoinProject/skycoin/src/cipher"
 	"github.com/SkycoinProject/skycoin/src/cipher/bip44"
+	"github.com/SkycoinProject/skycoin/src/util/file"
 )
 
 // TransactionsFinder interface for finding address related transaction hashes
@@ -290,12 +292,14 @@ func (serv *Service) NewAddresses(wltID string, password []byte, num uint64) ([]
 		}
 	}
 
+	// Checks if the wallet file is writable
+	wf := filepath.Join(serv.config.WalletDir, w.Filename())
+	if !file.IsWritable(wf) {
+		return nil, ErrWalletPermission
+	}
+
 	// Save the wallet first
 	if err := Save(w, serv.config.WalletDir); err != nil {
-		if os.IsPermission(err) {
-			logger.WithError(err).Warning("Create new addresses failed")
-			return nil, ErrWalletPermission
-		}
 		return nil, err
 	}
 

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -3,14 +3,12 @@ package wallet
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/SkycoinProject/skycoin/src/cipher"
 	"github.com/SkycoinProject/skycoin/src/cipher/bip44"
-	"github.com/SkycoinProject/skycoin/src/util/file"
 )
 
 // TransactionsFinder interface for finding address related transaction hashes
@@ -290,17 +288,6 @@ func (serv *Service) NewAddresses(wltID string, password []byte, num uint64) ([]
 		if err := f(w); err != nil {
 			return nil, err
 		}
-	}
-
-	// Check if the target wallet is writeable.
-	wltPath := filepath.Join(serv.config.WalletDir, w.Filename())
-	exist, err := file.Exists(wltPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if exist && file.IsWritable(wltPath) {
-		return nil, fmt.Errorf("Wallet %s is not writable", wltPath)
 	}
 
 	// Save the wallet first

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -292,6 +292,9 @@ func (serv *Service) NewAddresses(wltID string, password []byte, num uint64) ([]
 
 	// Save the wallet first
 	if err := Save(w, serv.config.WalletDir); err != nil {
+		if os.IsPermission(err) {
+			return nil, ErrWalletPermission
+		}
 		return nil, err
 	}
 

--- a/src/wallet/wallet.go
+++ b/src/wallet/wallet.go
@@ -82,6 +82,8 @@ var (
 	ErrInvalidWalletType = NewError(errors.New("invalid wallet type"))
 	// ErrWalletTypeNotRecoverable is returned by RecoverWallet is the wallet type does not support recovery
 	ErrWalletTypeNotRecoverable = NewError(errors.New("wallet type is not recoverable"))
+	// ErrWalletPermission is returned when updating a wallet without writting permission
+	ErrWalletPermission = NewError(errors.New("saving wallet permission denied"))
 )
 
 const (


### PR DESCRIPTION
Fixes #104

Changes:
- ~~Check if the wallet exists before saving~~
- Removing tmp file in `defer` so that the tmp file would be removed after leaving `func SaveBinary()`. We write data to tmp file cause we don't want users to lose their coins if there's power down when saving their wallet files. 

Todo:
- [x] Check if this workable on windows
- [x] Unit tests
- [x] Integration tests

Does this change need to mentioned in CHANGELOG.md?
Yes