### PR TITLE
Add cli command to create/sign a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Fix issue #7 #162, corrupted file in ~/.skycoin/data/ dir makes the desktop wallet show ERROR #1.
-- Fix issue #87, can not run web gui from skycoin docker image.
+- Add `createRawTransactionV2` CLI command, which calls the API of `/wallet/transaction` to create the transaction and can create then unsigned transaction. Once the API's performance issue has been fixed, we will replace the `createRawTransaction` with it.
+- Add `signTransaction` CLI command to sign transaction.
 - Do windows electron builds by travis and abandon the appveyor
 - Migrate `skycoin.net` to `skycoin.com`
 - Migrate project path to `SkycoinProject/skycoin`
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- #7, #162, corrupted file in ~/.skycoin/data/ dir makes the desktop wallet show ERROR #1.
+- #87, can not run web gui from skycoin docker image.
 - #2287 A `Content-Type` with a `charset` specified, for example `application/json; charset=utf-8`, will not return an HTTP 415 error anymore
 - Fix `fiber.toml` transaction verification parameters ignored by newcoin
 - #2373 Fix and clean-up further panics with various `skycoin-cli` commands (lastBlocks, checkdb) which were not correctly handling arguments.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ scratch, to remedy the rough edges in the Bitcoin design.
 - [Daemon CLI Options](#daemon-cli-options)
 - [URI Specification](#uri-specification)
 - [Wire protocol user agent](#wire-protocol-user-agent)
+- [Offline transaction signing](#offline-transaction-signing)
 - [Development](#development)
 	- [Modules](#modules)
 	- [Client libraries](#client-libraries)
@@ -245,6 +246,74 @@ However, do not use this URI in QR codes displayed to the user, because the addr
 ## Wire protocol user agent
 
 [Wire protocol user agent description](https://github.com/SkycoinProject/skycoin/wiki/Wire-protocol-user-agent)
+
+## Offline transaction signing
+
+Before doing the offline transaction signing, we need to have the unsigned transaction created. Using the `skycoin-cli` tool to create an unsigned transaction in hot wallet, and copy the hex encoded transaction to the computer where the cold wallet is installed. Then use the `skycoin-cli` tool to sign it offline.
+
+### Create an unsigned transaction
+
+The `skycoin-cli` tool replys on the APIs of the `skycoin node`, hence we have to start the node before running the tool.
+
+ Go to the project root and run:
+
+```bash
+$ ./run-client.sh -launch-browser=false
+```
+
+Once the node is started, we could use the following command to create an unsigned transaction.
+
+```bash
+$ skycoin-cli createRawTransactionV2 $WALLET_FILE $RECIPIENT_ADDRESS $AMOUNT --unsign
+```
+
+> Note: Don't forget the `--unsign` flag, otherwise it would try to sign the transaction.
+
+<details>
+ <summary>View Output</summary>
+
+```json
+b700000000e6b869f570e2bfebff1b4d7e7c9e86885dbc34d6de988da6ff998e7acd7e6e14010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000007531184ad0afeebbff2049b855e0921329cb1cb74d769ac57c057c9c8bd2b6810100000000ed5ea2ca4fe9b4560409b50c5bf7cb39b6c5ff6e50690f00000000000000000000000000
+```
+
+</details>
+
+Copy and save the generated transaction string. We will sign it with a cold wallet offline in the next section.
+
+### Sign the transaction
+
+The `skycoin node` needs to have the most recently `DB` so that the user would not lose much coin hours when signing the transaction. We could copy the full synchronized `data.db` from the hot wallet to the computer where the cold wallet is installed. And place it in `$HOME/.skycoin/data.db`. Then start the node with the network disabled.
+
+```bash
+$ ./run-client.sh -launch-browser=false -disable-networking
+```
+
+Run the following command to sign the transaction:
+
+```bash
+$ skycoin-cli signTransaction $RAW_TRANSACTION
+```
+
+The `$RAW_TRANSACTION` is the transaction string that we generated in the hot wallet.
+
+If the cold wallet is encrypted, you will be prompted to enter the password to sign the transaction.
+
+<details>
+ <summary>View Output</summary>
+
+```json
+b700000000e6b869f570e2bfebff1b4d7e7c9e86885dbc34d6de988da6ff998e7acd7e6e14010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000007531184ad0afeebbff2049b855e0921329cb1cb74d769ac57c057c9c8bd2b6810100000000ed5ea2ca4fe9b4560409b50c5bf7cb39b6c5ff6e50690f00000000000000000000000000
+```
+
+</details>
+
+Once the transaction is signed, we could copy and save the signed transaction string and broadcast it in the hot wallet.
+
+```bash
+$ skycoin-cli broadcastTransaction $SIGNED_RAW_TRANSACTION
+```
+
+A transaction id would be returned and you can check it in the [explorer](https://explorer.skycoin.com).
 
 ## Development
 

--- a/cmd/skycoin-cli/README.md
+++ b/cmd/skycoin-cli/README.md
@@ -20,6 +20,8 @@ The CLI command APIs can be used directly from a Go application, see [Skycoin CL
 	- [Check block data](#check-block-data)
 	- [Check database integrity](#check-database-integrity)
 	- [Create a raw transaction](#create-a-raw-transaction)
+    - [Create an unsigned raw transaction](#create-an-unsigned-raw-transaction)
+    - [Sign an unsigned raw transaction](#sign-an-unsigned-raw-transaction)
 	- [Decode a raw transaction](#decode-a-raw-transaction)
 	- [Encode a JSON transaction](#encode-a-json-transaction)
 	- [Broadcast a raw transaction](#broadcast-a-raw-transaction)
@@ -722,6 +724,49 @@ $ skycoin-cli createRawTransaction $WALLET_FILE $RECIPIENT_ADDRESS $AMOUNT -a $F
 }
 ```
 </details>
+
+### Create an unsigned raw transaction
+
+```bash
+$ skycoin-cli createRawTransactionV2 [wallet] [to address] [amount] [flags]
+```
+
+### Example
+
+```bash
+$ skycoin-cli createRawTransactionV2 $WALLET_FILE $RECIPIENT_ADDRESS $AMOUNT --unsign
+```
+
+<details>
+ <summary>View Output</summary>
+
+```json
+b700000000e6b869f570e2bfebff1b4d7e7c9e86885dbc34d6de988da6ff998e7acd7e6e14010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000007531184ad0afeebbff2049b855e0921329cb1cb74d769ac57c057c9c8bd2b6810100000000ed5ea2ca4fe9b4560409b50c5bf7cb39b6c5ff6e50690f00000000000000000000000000
+```
+
+</details>
+
+### Sign an unsigned raw transaction
+
+```bash
+$ skycoin-cli signTransaction [wallet] [raw transaction]
+```
+
+### Example
+
+```bash
+$ skycoin-cli signTransaction $WALLET_FILE $RAW_TRANSACTION
+```
+
+<details>
+ <summary>View Output</summary>
+
+```json
+b700000000e6b869f570e2bfebff1b4d7e7c9e86885dbc34d6de988da6ff998e7acd7e6e14010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000007531184ad0afeebbff2049b855e0921329cb1cb74d769ac57c057c9c8bd2b6810100000000ed5ea2ca4fe9b4560409b50c5bf7cb39b6c5ff6e50690f00000000000000000000000000
+```
+
+</details>
+
 
 ### Decode a raw transaction
 ```bash

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -186,6 +186,7 @@ func NewCLI(cfg Config) (*cobra.Command, error) {
 		checkDBCmd(),
 		checkDBEncodingCmd(),
 		createRawTxnCmd(),
+		signTxnCmd(),
 		decodeRawTxnCmd(),
 		encodeJSONTxnCmd(),
 		decryptWalletCmd(),

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -186,6 +186,7 @@ func NewCLI(cfg Config) (*cobra.Command, error) {
 		checkDBCmd(),
 		checkDBEncodingCmd(),
 		createRawTxnCmd(),
+		createRawTxnV2Cmd(),
 		signTxnCmd(),
 		decodeRawTxnCmd(),
 		encodeJSONTxnCmd(),

--- a/src/cli/create_rawtx.go
+++ b/src/cli/create_rawtx.go
@@ -110,7 +110,12 @@ func createRawTxnV2Cmd() *cobra.Command {
 
     Note: The [amount] argument is the coins you will spend, with decimal formatting, e.g. 1, 1.001 or 1.000000.
 
-    The [to address] and [amount] arguments can be replaced with the --csv option.`,
+    The [to address] and [amount] arguments can be replaced with the --csv option.,
+
+    Use caution when using the "-p" command. If you have command history enabled
+    your wallet encryption password can be recovered from the history log. If you
+    do not include the "-p" option you will be prompted to enter your password
+    after you enter your command.`,
 		SilenceUsage: true,
 		Args:         cobra.MinimumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {

--- a/src/cli/create_rawtx.go
+++ b/src/cli/create_rawtx.go
@@ -110,12 +110,7 @@ func createRawTxnV2Cmd() *cobra.Command {
 
     Note: The [amount] argument is the coins you will spend, with decimal formatting, e.g. 1, 1.001 or 1.000000.
 
-    The [to address] and [amount] arguments can be replaced with the --many/-m or the --csv option.
-
-    Use caution when using the "-p" command. If you have command history enabled
-    your wallet encryption password can be recovered from the history log. If you
-    do not include the "-p" option you will be prompted to enter your password
-    after you enter your command.`,
+    The [to address] and [amount] arguments can be replaced with the --csv option.`,
 		SilenceUsage: true,
 		Args:         cobra.MinimumNArgs(3),
 		RunE: func(c *cobra.Command, args []string) error {
@@ -152,7 +147,7 @@ func createRawTxnV2Cmd() *cobra.Command {
 
 	// createRawTxnCmd.Flags().StringP("change-address", "c", "", `Specify the change address.
 	// Defaults to one of the spending addresses (deterministic wallets) or to a new change address (bip44 wallets).`)
-	createRawTxnCmd.Flags().StringP("password", "p", "", "Wallet password")
+	// createRawTxnCmd.Flags().StringP("password", "p", "", "Wallet password")
 	createRawTxnCmd.Flags().BoolP("unsign", "", false, "Do not sign the transaction")
 	createRawTxnCmd.Flags().BoolP("json", "j", false, "Returns the results in JSON format.")
 	// createRawTxnCmd.Flags().String("csv", "", "CSV file containing addresses and amounts to send")
@@ -220,13 +215,7 @@ func makeWalletCreateTransactionRequest(c *cobra.Command, args []string) (*api.W
 	}
 
 	if w.IsEncrypted() && !unsign {
-		p, err := c.Flags().GetString("password")
-		if err != nil {
-			return nil, err
-		}
-
-		pr := NewPasswordReader([]byte(p))
-		password, err := pr.Password()
+		password, err := readPasswordFromTerminal()
 		if err != nil {
 			return nil, err
 		}

--- a/src/cli/transaction.go
+++ b/src/cli/transaction.go
@@ -360,7 +360,8 @@ func signTxnCmd() *cobra.Command {
 				return err
 			}
 
-			if len(txn.Sigs) != 0 {
+			emptySig := cipher.Sig{}
+			if len(txn.Sigs) > 0 && txn.Sigs[0] != emptySig {
 				return fmt.Errorf("Transaction already signed")
 			}
 


### PR DESCRIPTION
Fixes #165, #135 

Changes:
- Add `signTransaction` cli command to sign transaction
- Add `createRawTransactionV2` cli command, which provides the `--unsign` option to create a transaction without signing.


Before adding the `createRawTransactionV2` command, it is difficult to create an unsigned transaction. The only way to do this is calling the api of `/wallet/transaction`. 

TODO:
- [x] Finish the `csv` option supporting so that it can send coins to multiple addresses
- [x] Add document to describe how to create an unsigned transaction and sign it offline
- [x] Update changelog
- [ ] Fix the performance issue that caused by the api `/wallet/transaction`.

Does this change need to mentioned in CHANGELOG.md?
Yes