### PR TITLE
Break the travis build if has lint error

### DIFF
--- a/ci-scripts/lint-and-test.sh
+++ b/ci-scripts/lint-and-test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -o pipefail
+
 make check-newcoin
 make lint
 make test-386


### PR DESCRIPTION
Changes:
- Add `set -e -o pipefail` to the `ci-scripts/lint-and-test.sh` so that the travis build won't ignore the errors the script returns.

Does this change need to mentioned in CHANGELOG.md?
No