### PR TITLE
Add src_txid to verbose transaction inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+### Fixed
+
+### Changed
+
+- Add `src_txid` to verbose transaction inputs, affected apis: `/api/v1/transaction`, `/api/v1/transactions` `/api/v1/block` `/api/v1/blocks` `/api/v1/pendingTxs`
+
+### Removed
+
 ## [0.27.0] - 2019-11-26
 
 ### Added

--- a/ci-scripts/integration-test-stable.sh
+++ b/ci-scripts/integration-test-stable.sh
@@ -45,6 +45,19 @@ usage () {
   exit 1
 }
 
+shutdown_node() {
+    COIN=$1
+    PID=$2
+    BIN=$3
+    echo "shutting down $COIN node"
+
+    # Shutdown skycoin node
+    kill -s SIGINT $PID
+    wait $PID
+
+    rm "$BIN"
+}
+
 while getopts "h?t:r:n:uvcxd" args; do
   case $args in
     h|\?)
@@ -125,39 +138,31 @@ set +e
 
 if [[ -z $TEST || $TEST = "api" ]]; then
 
-SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE SKYCOIN_NODE_HOST=$HOST \
-	USE_CSRF=$USE_CSRF HEADER_CHECK=$HEADER_CHECK DB_NO_UNCONFIRMED=$DB_NO_UNCONFIRMED COIN=$COIN \
-    go test -count=1 ./src/api/integration/... $UPDATE -timeout=10m $VERBOSE $RUN_TESTS
+    SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE SKYCOIN_NODE_HOST=$HOST \
+    	USE_CSRF=$USE_CSRF HEADER_CHECK=$HEADER_CHECK DB_NO_UNCONFIRMED=$DB_NO_UNCONFIRMED COIN=$COIN \
+        go test -count=1 ./src/api/integration/... $UPDATE -timeout=10m $VERBOSE $RUN_TESTS
 
-API_FAIL=$?
+    API_FAIL=$?
+
+    if [[ $API_FAIL -ne 0 ]]; then
+        shutdown_node $COIN $SKYCOIN_PID $BINARY
+        exit $API_FAIL
+    fi
 
 fi
 
 if [[ -z $TEST  || $TEST = "cli" ]]; then
 
-SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE RPC_ADDR=$RPC_ADDR \
-	USE_CSRF=$USE_CSRF HEADER_CHECK=$HEADER_CHECK DB_NO_UNCONFIRMED=$DB_NO_UNCONFIRMED COIN=$COIN \
-    go test -count=1 ./src/cli/integration/... $UPDATE -timeout=10m $VERBOSE $RUN_TESTS
+    SKYCOIN_INTEGRATION_TESTS=1 SKYCOIN_INTEGRATION_TEST_MODE=$MODE RPC_ADDR=$RPC_ADDR \
+    	USE_CSRF=$USE_CSRF HEADER_CHECK=$HEADER_CHECK DB_NO_UNCONFIRMED=$DB_NO_UNCONFIRMED COIN=$COIN \
+        go test -count=1 ./src/cli/integration/... $UPDATE -timeout=10m $VERBOSE $RUN_TESTS
 
-CLI_FAIL=$?
+    CLI_FAIL=$?
+    if [[ $CLI_FAIL -ne 0 ]]; then
+        shutdown_node $COIN $SKYCOIN_PID $BINARY
+        exit $CLI_FAIL
+    fi
 
 fi
 
-
-echo "shutting down $COIN node"
-
-# Shutdown skycoin node
-kill -s SIGINT $SKYCOIN_PID
-wait $SKYCOIN_PID
-
-rm "$BINARY"
-
-
-if [[ (-z $TEST || $TEST = "api") && $API_FAIL -ne 0 ]]; then
-  exit $API_FAIL
-elif [[ (-z $TEST || $TEST = "cli") && $CLI_FAIL -ne 0 ]]; then
-  exit $CLI_FAIL
-else
-  exit 0
-fi
-# exit $FAIL
+shutdown_node $COIN $SKYCOIN_PID $BINARY

--- a/ci-scripts/integration-test-stable.sh
+++ b/ci-scripts/integration-test-stable.sh
@@ -46,16 +46,16 @@ usage () {
 }
 
 shutdown_node() {
-    COIN=$1
-    PID=$2
-    BIN=$3
+    local coin=$1
+    local pid=$2
+    local bin=$3
     echo "shutting down $COIN node"
 
     # Shutdown skycoin node
-    kill -s SIGINT $PID
-    wait $PID
+    kill -s SIGINT $pid
+    wait $pid
 
-    rm "$BIN"
+    rm "$bin"
 }
 
 while getopts "h?t:r:n:uvcxd" args; do

--- a/src/api/integration/testdata/address-transactions-2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6.golden
+++ b/src/api/integration/testdata/address-transactions-2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6.golden
@@ -49,6 +49,7 @@
 					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
+					"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 					"hours": 100000000000000,
 					"calculated_hours": 100000000000000
 				}
@@ -680,6 +681,7 @@
 					"uxid": "fa2b598d233fe434f907f858d5de812eacf50c7b3fd152c77cd6e246fe356a9e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999890.000000",
+					"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 					"hours": 4073,
 					"calculated_hours": 6061184
 				}
@@ -723,6 +725,7 @@
 					"uxid": "c603e99ceae4d15c20360714ee07ba6e3a944a97ea9285d164c23252e93958b6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -760,6 +763,7 @@
 					"uxid": "18ea1b3cceb2ca40c01efc8f3cfd7d1d0dd69430ecdf655515aa4f8b21bd2644",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "260d249883165aa9e59e17fb2bd8ba8995d2c3644993530985f8b813ed378650",
 					"hours": 78,
 					"calculated_hours": 78
 				}
@@ -803,6 +807,7 @@
 					"uxid": "64194899d317e2a007f89df14538795547e927c242a92f83180e6cc952304964",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "5.000000",
+					"src_txid": "9004c779cff67b3895500ec14b2c2e566127bb11a8af3358fe8a63dcfae9badc",
 					"hours": 9,
 					"calculated_hours": 9
 				}
@@ -841,6 +846,7 @@
 					"uxid": "569aa1260e734017c4eee06d84ab4a6285e2ca2041940b2915d9141527caf179",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "5.000000",
+					"src_txid": "9004c779cff67b3895500ec14b2c2e566127bb11a8af3358fe8a63dcfae9badc",
 					"hours": 9,
 					"calculated_hours": 9
 				},
@@ -848,6 +854,7 @@
 					"uxid": "eb446b8372559249c8e269b6cd028588e2e9e4f8fe9357719da9d1c22aa29911",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "5.000000",
+					"src_txid": "327375203f20cb68847351c30a48597c0588a8c14319a4eb47bf440207fd045a",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -885,6 +892,7 @@
 					"uxid": "e702df2703c3de180f3e4a0e9a503bd534037c2d68e858e97a317575c5a97d95",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "e89ee3e90e72108e4cd6ccb95c9f8d2b18ccfaa7ce61a7d297454debd69cebbf",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -928,6 +936,7 @@
 					"uxid": "10998e83dc5dfe3c3f5f28ef3e5e2fced4dbd1da389678b0ea3ddb552851b6bf",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "6.000000",
+					"src_txid": "08bf0f8f4a8547bcab1fef035adac2a66c80369b4485a736bdd676e782bbb037",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -966,6 +975,7 @@
 					"uxid": "41c6d29aa5de770de684ab19b40bd75b99ec7f1a5ff7d15288ae4bfff568eabd",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "4.000000",
+					"src_txid": "08bf0f8f4a8547bcab1fef035adac2a66c80369b4485a736bdd676e782bbb037",
 					"hours": 0,
 					"calculated_hours": 0
 				},
@@ -973,6 +983,7 @@
 					"uxid": "9e5779445f60d62b471862339d7a83dd8355c7a89d5fc3b751f98e9414628ec2",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "6.000000",
+					"src_txid": "3170f0635cc40aded3a38f84f2ae07bd2238550ea4ee867328d0f891ea9abf14",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1010,6 +1021,7 @@
 					"uxid": "d46e91fea3c8a6428885f941e5152dbc7f9abd356ad4d054bf20e0e806f1ec99",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "fba515a9eeaedb891c4dca862bd06108e0452270890b362f0b353b4c86845618",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1047,6 +1059,7 @@
 					"uxid": "cb8efc0b1082c39258cb6efd59f64d88b36fcb60143c826829fc5f0ed5c0d668",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944790.000000",
+					"src_txid": "df622e8c9dfaed1d7dca83ad7f6d8946bb86b81398bad521d858cbefef8e4688",
 					"hours": 400470,
 					"calculated_hours": 400470
 				}
@@ -1090,6 +1103,7 @@
 					"uxid": "a6061defc41a8a55e37eaf56ebaa1177446f61719b1d5126698e79a6023f5367",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944780.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50058
 				}
@@ -1133,6 +1147,7 @@
 					"uxid": "3b5f72e772ea886dd872b9087395398133576a6561072d5294fbcd04b49e1d95",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944770.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6257
 				}
@@ -1176,6 +1191,7 @@
 					"uxid": "f265bea876ffcfb8cf64df3aca4dae4a8d7f424ff495d91fb322feddb3a7e505",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944760.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 782
 				}
@@ -1223,6 +1239,7 @@
 					"uxid": "2987e7c89d353ad5d63cea2bf2724dc5f7a5ef5fb81f5ea160a307f0726ac2f5",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "9fb039cd90a4e9b85669bd6ef878b98a9e84eec7d4804e2bff6f0dc9c2739c44",
 					"hours": 0,
 					"calculated_hours": 701
 				},
@@ -1230,6 +1247,7 @@
 					"uxid": "a52408daa8ce7026c70b61d4df4212fb577462060f340bfce779225b3e18193d",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50605
 				},
@@ -1237,6 +1255,7 @@
 					"uxid": "dc73aac74348dd285a1456c1fae2204d7c2039d50a765bdaae0c31f7c7e059db",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6804
 				},
@@ -1244,6 +1263,7 @@
 					"uxid": "e4e375b9dc55ff53d6de9120f1a87ff00e00a779835f8320f2c6b3090d0466e6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 1329
 				},
@@ -1251,6 +1271,7 @@
 					"uxid": "d11b05345917d171f60c31bd2634041b73b97eae364724369ddb8d53369397fb",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 644
 				}
@@ -1288,6 +1309,7 @@
 					"uxid": "998487775c0e58420673b70204b83c1d6bb5b70e34b1aa0f8169c85ecec2438e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "765600.000000",
+					"src_txid": "211f5fc97ba1797d78f84d4e4db78415b5ff4121f78369535fe3f8015571c6df",
 					"hours": 47330,
 					"calculated_hours": 47330
 				}

--- a/src/api/integration/testdata/address-transactions-ALJVNKYL7WGxFBSriiZuwZKWD4b7fbV1od.golden
+++ b/src/api/integration/testdata/address-transactions-ALJVNKYL7WGxFBSriiZuwZKWD4b7fbV1od.golden
@@ -22,6 +22,7 @@
 					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
+					"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 					"hours": 100000000000000,
 					"calculated_hours": 100000000000000
 				}

--- a/src/api/integration/testdata/address-transactions-R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ.golden
+++ b/src/api/integration/testdata/address-transactions-R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ.golden
@@ -22,6 +22,7 @@
 					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
+					"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 					"hours": 100000000000000,
 					"calculated_hours": 100000000000000
 				}
@@ -653,6 +654,7 @@
 					"uxid": "e3e72ee077c8b0c3f87da7cf50cad8876bd3f489f373d9fe82fc2e971df56f76",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "1000000.000000",
+					"src_txid": "86564b421cd3d4fe6f5f2d7a3e5db9d6fc340892bddd3a150533dff7036d0efe",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -696,6 +698,7 @@
 					"uxid": "af0b2c1cc882a56b6c0c06e99e7d2731413b988329a2c47a5c2aa8be589b707a",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -733,6 +736,7 @@
 					"uxid": "0cd548e03bd13bca8647cd13f6baef0c65fd03081aeb6dc3695536e5bc6018ae",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999990.000000",
+					"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 					"hours": 1,
 					"calculated_hours": 5556
 				}
@@ -777,6 +781,7 @@
 					"uxid": "9eb7954461ba0256c9054fe38c00c66e60428dccf900a62e74b9fe39310aea13",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10.000000",
+					"src_txid": "a6a709e9388a4d67a47d262b11da5f804eddd9d67acc4a3e450f7a567bdc1619",
 					"hours": 0,
 					"calculated_hours": 2405
 				},
@@ -784,6 +789,7 @@
 					"uxid": "706f82c481906108880d79372ab5c126d32ecc98cf3f7c74cf33f5fda49dcf70",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999980.000000",
+					"src_txid": "c24b92898381fbebe59a457924184f4cce1e7166e140ca75aea5baf854c1ab75",
 					"hours": 3704,
 					"calculated_hours": 3704
 				}
@@ -827,6 +833,7 @@
 					"uxid": "fa2b598d233fe434f907f858d5de812eacf50c7b3fd152c77cd6e246fe356a9e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999890.000000",
+					"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 					"hours": 4073,
 					"calculated_hours": 6061184
 				}
@@ -870,6 +877,7 @@
 					"uxid": "c603e99ceae4d15c20360714ee07ba6e3a944a97ea9285d164c23252e93958b6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -908,6 +916,7 @@
 					"uxid": "4168b9378363cd81939e667cf78055d35a60d3101f5f9e3d2ae709e3981e29fc",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999880.000000",
+					"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 					"hours": 4040790,
 					"calculated_hours": 4543507
 				},
@@ -915,6 +924,7 @@
 					"uxid": "d9dae1f82177f979b07016a341ed5c281ed6ed8eaa785a8a107ec16efbe541ef",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10.000000",
+					"src_txid": "686db0a8cd429970bb91163033703410d4750c86ba485709fe1a3faabbbb42f6",
 					"hours": 0,
 					"calculated_hours": 4
 				}
@@ -958,6 +968,7 @@
 					"uxid": "8793a3782bf673393a8f909f267f3bfcc713b600460893b571fd55f675ac65ba",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999880.000000",
+					"src_txid": "56e7bd13dc4c6e1cd80aba66a0a9fed650d0646659ac774e3f1b415848755d85",
 					"hours": 567938,
 					"calculated_hours": 567938
 				}
@@ -1001,6 +1012,7 @@
 					"uxid": "ad742bbc7420c08881e6ccf35e34e8472c0dd6386792359aedcfb752ca618c33",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999790.000000",
+					"src_txid": "cff53a059d55f2c90f6dd7ce7de2cc07cbdbd50b25867cba0f41cd0192614d0d",
 					"hours": 70992,
 					"calculated_hours": 3113963
 				}
@@ -1044,6 +1056,7 @@
 					"uxid": "108520145179c00f581d91e273714811fe6e82ee059d65218eea91154ebd8205",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "998790.000000",
+					"src_txid": "a76cd63b71f1f5425941cd567627e1dcdc8c34306a7945ea48755f5a46efb6f5",
 					"hours": 389245,
 					"calculated_hours": 389245
 				}
@@ -1087,6 +1100,7 @@
 					"uxid": "e79c94aa7013c7611901839236b8a1cdf70e8ef7c40b9e33f99359136de981d6",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "988790.000000",
+					"src_txid": "c38b47bd576e3bced2a9309c3df7622064e71177f54020d77193d5cac310719c",
 					"hours": 48655,
 					"calculated_hours": 48655
 				}
@@ -1130,6 +1144,7 @@
 					"uxid": "c65a9e6aa33244958e9595e9eceed678f9f17761753bf77000c5474f7696da53",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "978790.000000",
+					"src_txid": "b56f3e9239da5c5f9bb5ca80226b8454ba36ce6012f8e323a50c9d9c4eb4a834",
 					"hours": 6081,
 					"calculated_hours": 6081
 				}
@@ -1173,6 +1188,7 @@
 					"uxid": "195f5e50b4eed1ec7ff968feca90356285437adc8ccfcf6623b55a4eebf7bbb5",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "969790.000000",
+					"src_txid": "cf4fe76a08e3296b6f6abdb949604409be66574f211d9d14fde39103c4cfe1d6",
 					"hours": 760,
 					"calculated_hours": 3203760
 				}
@@ -1216,6 +1232,7 @@
 					"uxid": "cb8efc0b1082c39258cb6efd59f64d88b36fcb60143c826829fc5f0ed5c0d668",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944790.000000",
+					"src_txid": "df622e8c9dfaed1d7dca83ad7f6d8946bb86b81398bad521d858cbefef8e4688",
 					"hours": 400470,
 					"calculated_hours": 400470
 				}
@@ -1259,6 +1276,7 @@
 					"uxid": "a6061defc41a8a55e37eaf56ebaa1177446f61719b1d5126698e79a6023f5367",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944780.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50058
 				}
@@ -1302,6 +1320,7 @@
 					"uxid": "3b5f72e772ea886dd872b9087395398133576a6561072d5294fbcd04b49e1d95",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944770.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6257
 				}
@@ -1345,6 +1364,7 @@
 					"uxid": "f265bea876ffcfb8cf64df3aca4dae4a8d7f424ff495d91fb322feddb3a7e505",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944760.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 782
 				}
@@ -1388,6 +1408,7 @@
 					"uxid": "e6d9b56e075a6adf520d1ae7fbab9ae06353ae0b93dc8cb17d82cc3628009a50",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944750.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 23715
 				}
@@ -1431,6 +1452,7 @@
 					"uxid": "2df1e88589be43c55d7c6c3dbcbd663fb759b3245eb8d86b0b9cdaa989556aea",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "943750.000000",
+					"src_txid": "d154d8262abbf517c67d529b0fea7cdf097433bd296d5795b17c6379cb1b1430",
 					"hours": 2964,
 					"calculated_hours": 13450
 				}
@@ -1474,6 +1496,7 @@
 					"uxid": "c5150380691c542b9bdf4cf2280ac612e0576c349f99d47d0a03c77eedc48731",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "942750.000000",
+					"src_txid": "61a33b49e97bfe2d5f026bf45fae43a1b9bdf08c60ec8db017da720a69790c7f",
 					"hours": 1681,
 					"calculated_hours": 12156
 				}
@@ -1517,6 +1540,7 @@
 					"uxid": "9bbb8d620aae3efc7c21bb7d6a7159eda441a83e0fef2cd98f8240b38857d648",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "941750.000000",
+					"src_txid": "4aeafd20b9df56ec852a2c257ff1630b9530d8375a4e72f20238ea36835f76d5",
 					"hours": 1519,
 					"calculated_hours": 9366
 				}
@@ -1560,6 +1584,7 @@
 					"uxid": "25ad0d5ae6a1a9bc61c6b9099fb7829111977a59e1183de4227a0a5352555639",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "940750.000000",
+					"src_txid": "29c229c97d27bcaf842a367520e1916fb855921906bddf4a3b0413ad3f11517b",
 					"hours": 1170,
 					"calculated_hours": 11622
 				}
@@ -1603,6 +1628,7 @@
 					"uxid": "acc75d51ff9f18a224d1ca0481917e2a67298de40955711cd97a08f6733b5b6a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "939750.000000",
+					"src_txid": "42227683dd9c149859d0578ab300d8509d513afadf7834fd8ae7a321cc07d833",
 					"hours": 1452,
 					"calculated_hours": 1452
 				}
@@ -1646,6 +1672,7 @@
 					"uxid": "5c1069a3aa6628ed7f9bdb300bec1a7e7ca6fb4645528a8c6a27c167e7dfe698",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "938750.000000",
+					"src_txid": "d803ab903f68f7861cd8eff93b3c097c5b8f6a697ca67bb01e7e645060839fd0",
 					"hours": 181,
 					"calculated_hours": 181
 				}
@@ -1689,6 +1716,7 @@
 					"uxid": "8190fd31c005510d550c8a241b127fad2558c82aed9483fb4423193d5f4429e3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "913750.000000",
+					"src_txid": "3bf485890e91268452dc3136c0b294dc9909b3aaa10b9c936743e6e9b1a56f61",
 					"hours": 22,
 					"calculated_hours": 22
 				}
@@ -1732,6 +1760,7 @@
 					"uxid": "450cd7795bb3625daa99d6b64b9a8786d593bf1cad986d6c2933dae04b74a593",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "888750.000000",
+					"src_txid": "f51e2ce31961b0186e04cc9d78857c3c21d3e2afb25c050d8c1d67d3320fcc07",
 					"hours": 2,
 					"calculated_hours": 2
 				}
@@ -1775,6 +1804,7 @@
 					"uxid": "b44ee00208690c2123989f40edaff0224825afb20ca0952fbd90bddfd3213642",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "863750.000000",
+					"src_txid": "abed13c2a552633d26b5b51c3ac5abf9808756c0203869ed185a7cd673702ba2",
 					"hours": 0,
 					"calculated_hours": 7814538
 				}
@@ -1818,6 +1848,7 @@
 					"uxid": "6060c983054614b8801e405de697c443a1edebd3236582f89f01c6cf6a165c3f",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "862750.000000",
+					"src_txid": "29798149e90f6442489bcc3294f455441a5a401e81491ed06bdc2c850756f0d9",
 					"hours": 976817,
 					"calculated_hours": 1005575
 				}
@@ -1861,6 +1892,7 @@
 					"uxid": "129726406b3101d51ffd5bfca59a501184d6c8ca363be4ef1b8d8bf48a6c70e0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "861750.000000",
+					"src_txid": "0cded82aa3ac92d78e23d2d0d7faf93c675fc9a321ad55105f65b6fca444b1e7",
 					"hours": 125696,
 					"calculated_hours": 161602
 				}
@@ -1904,6 +1936,7 @@
 					"uxid": "05f42f22f5fea4b5cac8182dc2b4f280149c686434c6d4195a119a8d02ab24b2",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "861050.000000",
+					"src_txid": "b7b42b1b29acab0a2328aaf368ec74be49b4d4caf827e82b439ef4d8be976a55",
 					"hours": 20200,
 					"calculated_hours": 20200
 				}
@@ -1947,6 +1980,7 @@
 					"uxid": "4e1a98a72639efa6253a7cbea0f3b499fa24fb88612ad81414d20e46d2b5784e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "860050.000000",
+					"src_txid": "ca51f9d0a19bf326d6dd39a1e4dd240adaaae279411093d4a5b20f54cddabb95",
 					"hours": 2525,
 					"calculated_hours": 21637
 				}
@@ -1990,6 +2024,7 @@
 					"uxid": "33e0c4c9536afffd491fef6294f22ffb0d16902493946a051db0b218728a1c44",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "859050.000000",
+					"src_txid": "bd617ec27c2bea642fad8c153178e11ca08456d752249324e3011f27c845f87a",
 					"hours": 2704,
 					"calculated_hours": 14635
 				}
@@ -2033,6 +2068,7 @@
 					"uxid": "f32f03f28eece9ddcdc488a85100c94a7c924c185ae560363518dae5e2aacccb",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "858050.000000",
+					"src_txid": "0f4958d590ed4ac9aca79d848731b358b1c01fab9717775cf6515f2bf2706dc8",
 					"hours": 1829,
 					"calculated_hours": 94784
 				}
@@ -2080,6 +2116,7 @@
 					"uxid": "2987e7c89d353ad5d63cea2bf2724dc5f7a5ef5fb81f5ea160a307f0726ac2f5",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "9fb039cd90a4e9b85669bd6ef878b98a9e84eec7d4804e2bff6f0dc9c2739c44",
 					"hours": 0,
 					"calculated_hours": 701
 				},
@@ -2087,6 +2124,7 @@
 					"uxid": "a52408daa8ce7026c70b61d4df4212fb577462060f340bfce779225b3e18193d",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50605
 				},
@@ -2094,6 +2132,7 @@
 					"uxid": "dc73aac74348dd285a1456c1fae2204d7c2039d50a765bdaae0c31f7c7e059db",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6804
 				},
@@ -2101,6 +2140,7 @@
 					"uxid": "e4e375b9dc55ff53d6de9120f1a87ff00e00a779835f8320f2c6b3090d0466e6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 1329
 				},
@@ -2108,6 +2148,7 @@
 					"uxid": "d11b05345917d171f60c31bd2634041b73b97eae364724369ddb8d53369397fb",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 644
 				}
@@ -2145,6 +2186,7 @@
 					"uxid": "6002f3afc7054c0e1161bcf2b4c1d4d1009440751bc1fe806e0eae33291399f4",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "27000.000000",
+					"src_txid": "0301358c2db5314ca43c442bac3c1daf31f4b39f9ac9e22dc157687212cab703",
 					"hours": 220,
 					"calculated_hours": 823240
 				}
@@ -2185,6 +2227,7 @@
 					"uxid": "99b4e51e1afd04813656e6202c7e462d88ce87ba980da7a62591190d72d1073c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "858000.000000",
+					"src_txid": "fe01250cfdf84eb0182c033c216891e7e6971cc85976c4c46d9e3c608974d233",
 					"hours": 11848,
 					"calculated_hours": 962798
 				},
@@ -2192,6 +2235,7 @@
 					"uxid": "f12164a6ea6ce65ff2ca1f2be7251bece8f7c5747ba8ec68e1ec3b27d45d7b9c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "50.000000",
+					"src_txid": "fe01250cfdf84eb0182c033c216891e7e6971cc85976c4c46d9e3c608974d233",
 					"hours": 11848,
 					"calculated_hours": 11903
 				},
@@ -2199,6 +2243,7 @@
 					"uxid": "427462efeb07a6803f013c789ea43d93240f74f886bf9afd63dc1936a7574a37",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "50.000000",
+					"src_txid": "819106dc50373e5293a7e79f179693e85536e8206d82272930ec08410d92402a",
 					"hours": 7510,
 					"calculated_hours": 7564
 				},
@@ -2206,6 +2251,7 @@
 					"uxid": "f9bffdcbe252acb1c3a8a1e8c99829342ba1963860d5692eebaeb9bcfbcaf274",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "27000.000000",
+					"src_txid": "e8fe5290afba3933389fd5860dca2cbcc81821028be9c65d0bb7cf4e8d2c4c18",
 					"hours": 102905,
 					"calculated_hours": 132080
 				}
@@ -2249,6 +2295,7 @@
 					"uxid": "dfd2834342f3a7caf183472c17801aafacd1775378eb843509d17ad858456cb0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "885000.000000",
+					"src_txid": "8de17dff34a8798f2ac89584f5c559e3bb82c280a3f6890386b4dbc5fef0e8cf",
 					"hours": 139293,
 					"calculated_hours": 139293
 				}
@@ -2292,6 +2339,7 @@
 					"uxid": "8ac39d41ec014ca6625e5f17e1fbe62db7a4ac154e0e42a017efa037935ae968",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "884900.000000",
+					"src_txid": "6546dfbe6e61e81f3e9f6c9afdfee1c07758f2e486d731ae4d19b40602367656",
 					"hours": 17411,
 					"calculated_hours": 56739
 				}
@@ -2335,6 +2383,7 @@
 					"uxid": "f9bf35f993452b3d490668bb579fd272da969a1bcca8de0c25000ee57b5d7f54",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "22700.000000",
+					"src_txid": "552a4b194478325ee9f3e4a8648d94bc8eb26432be6fecc881bf71ff9ca15356",
 					"hours": 17848,
 					"calculated_hours": 17848
 				}
@@ -2379,6 +2428,7 @@
 					"uxid": "bae0e928b795e2a80c88161afcbc102dcad6644386f6f44050dde8d586750140",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "881900.000000",
+					"src_txid": "a4c15ae4743246709ec335d33c289576c8893e71f5c3dcee1db6e43eec9242ee",
 					"hours": 7092,
 					"calculated_hours": 11108253
 				},
@@ -2386,6 +2436,7 @@
 					"uxid": "94889dbe1c20eb942b7932c5301737537ac33abd9c81d72e1642ddc70ce320e0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10000.000000",
+					"src_txid": "6ce27da2ddbc15f03330960b4201dbb3a066ad2e9bbd5366a9564f6befdcae2e",
 					"hours": 2231,
 					"calculated_hours": 2231
 				}
@@ -2429,6 +2480,7 @@
 					"uxid": "1d4595b9fa1c6c3d64f48b6ae5f8f861b1c08a022cbcb04b279df448da3db660",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873900.000000",
+					"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 					"hours": 1388810,
 					"calculated_hours": 1388810
 				}
@@ -2472,6 +2524,7 @@
 					"uxid": "412eff3eef889c682da8db3608fce37d1c5ee2cc297bc88d901648e6ccd418f9",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873800.000000",
+					"src_txid": "1f27afc41896d2c7fdbd2620e606440ad12557e9a4bdd6808dcc2c23d4e32978",
 					"hours": 173601,
 					"calculated_hours": 173601
 				}
@@ -2515,6 +2568,7 @@
 					"uxid": "6ad7993fb2728c2c53ac2c8395a6c62d03c5ef9298ca467e7998fb64fd0c90b4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873700.000000",
+					"src_txid": "e8765b4e6fbca87144df59a6f66815b175e81999509504b117636edc34cbe2af",
 					"hours": 21700,
 					"calculated_hours": 21700
 				}
@@ -2558,6 +2612,7 @@
 					"uxid": "0976005ab4540e8211cd929f19634bfaa2f5d8e24177ddb5b803b447ea91f8c3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873600.000000",
+					"src_txid": "bb700553c3e1a32346912ab311fa38793d929f311daeee0b167fa81c1369717e",
 					"hours": 2712,
 					"calculated_hours": 167725
 				}
@@ -2601,6 +2656,7 @@
 					"uxid": "6beca9fb58a327580c614d7fb5622916849756790b661bcabc880666364fdf47",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "863600.000000",
+					"src_txid": "345488861ad3f0d93024c367990e64ef0f7a95bd8b8589f554172f9439808263",
 					"hours": 20965,
 					"calculated_hours": 3029171
 				}
@@ -2644,6 +2700,7 @@
 					"uxid": "f8a1990492f970227ec29e6e095fa724d66fa2d6883bd8723773098d08ca8b3c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "801600.000000",
+					"src_txid": "da82deafc15c36e7dc9cd95663e0dc910ae626ee543147ac7bd8682be00f7baf",
 					"hours": 378646,
 					"calculated_hours": 378646
 				}
@@ -2687,6 +2744,7 @@
 					"uxid": "998487775c0e58420673b70204b83c1d6bb5b70e34b1aa0f8169c85ecec2438e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "765600.000000",
+					"src_txid": "211f5fc97ba1797d78f84d4e4db78415b5ff4121f78369535fe3f8015571c6df",
 					"hours": 47330,
 					"calculated_hours": 47330
 				}
@@ -2730,6 +2788,7 @@
 					"uxid": "6fb116c110fe391448a1dcb985b67439c2e9a71d8bb2fd1cf345ac73ada6166a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "755600.000000",
+					"src_txid": "9003d3caba9587d46d000cc614bb52bed34adcc5ea404c560c986eb6dd756e6b",
 					"hours": 5916,
 					"calculated_hours": 5916
 				}
@@ -2773,6 +2832,7 @@
 					"uxid": "04471fb0797bb931e883f7b95cfff6ee4fea5e19a352ca5425fcd353c4f6aba4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "750600.000000",
+					"src_txid": "e9a6dd585b564b19c55d9f56188a45bfad32fa75703fa6336830035f6fa92e3d",
 					"hours": 739,
 					"calculated_hours": 739
 				}
@@ -2817,6 +2877,7 @@
 					"uxid": "c5df36ce47f6f183475317ab1c53eaa65428c142cb3e3906bf162d80519a203f",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "12700.000000",
+					"src_txid": "6ce27da2ddbc15f03330960b4201dbb3a066ad2e9bbd5366a9564f6befdcae2e",
 					"hours": 2231,
 					"calculated_hours": 1175478
 				},
@@ -2824,6 +2885,7 @@
 					"uxid": "53b376413d550663ab51b229df8b0f55e4055d6577c2d8b5cec8ff748fe0e958",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "18000.000000",
+					"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 					"hours": 1388810,
 					"calculated_hours": 3051530
 				}
@@ -2868,6 +2930,7 @@
 					"uxid": "6b616ad99a946538c3ab101f245bcab211ab39507848425e80cbfc8ec5bdbc67",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "738100.000000",
+					"src_txid": "1ca0a2d44b6439b91eb839e0f99405abdcafe2c1a49c8b49b1739498129bd1a6",
 					"hours": 92,
 					"calculated_hours": 55430171
 				},
@@ -2875,6 +2938,7 @@
 					"uxid": "ef488d5f4a019502115d3b6b50bd364692315c3954d7e93c3ca22e11b92fc528",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "100.000000",
+					"src_txid": "243e1baa955c3f0af42d7acc4c920437dd0a99c754d6c5c2b7defcd143ff288d",
 					"hours": 528376,
 					"calculated_hours": 528376
 				}
@@ -2918,6 +2982,7 @@
 					"uxid": "ecb92dc2f43d4c6ca124575d8456d8894f3cb137875287beaa73180fcae2b3ca",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "737200.000000",
+					"src_txid": "c2c9fe882df3b44fbb125b251a7604a7a4f4195dddff6e5396b7f130744e2b27",
 					"hours": 6994818,
 					"calculated_hours": 101676076
 				}
@@ -2961,6 +3026,7 @@
 					"uxid": "6b4ca83b3f73b62161c90c6da03dff460ca9a5a3ccd6fafca140137416dedc58",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "736000.000000",
+					"src_txid": "6538399868cf772fcfa96e68c51aa6aa66faa95d7c685432e4005880932be134",
 					"hours": 12709509,
 					"calculated_hours": 12709509
 				}
@@ -3004,6 +3070,7 @@
 					"uxid": "2cd58783beb8a9f6278f7a097151531091b5f15afd7735e1facf02aa720c1191",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "735000.000000",
+					"src_txid": "3dfdfea4614d05c2f5eddf5773ef0afc745f1afe585141659df8e03e82897606",
 					"hours": 1588688,
 					"calculated_hours": 1588688
 				}
@@ -3047,6 +3114,7 @@
 					"uxid": "52288a441c70260f6a3eab0e271969d54492377615a6fba8ec3ad26f11dc9768",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "734500.000000",
+					"src_txid": "d30cec3ad3a66562d2513a3656b366ea7da583e6ba45214ac12b9c2219b4c5ea",
 					"hours": 198586,
 					"calculated_hours": 198586
 				}
@@ -3090,6 +3158,7 @@
 					"uxid": "e29ec214f4afd79e6465d03e4d88e552dc69654750a725d74873ee366c58e552",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "734400.000000",
+					"src_txid": "44d05abc2637d9cd2047984023eb5cfa0a146e58821117de30f9c81703189cde",
 					"hours": 24823,
 					"calculated_hours": 24823
 				}
@@ -3133,6 +3202,7 @@
 					"uxid": "8ea58a3736b35f0e3781e94198e8b73bba2536704b84b15900fb32701db8893e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "733400.000000",
+					"src_txid": "072f0738f834db0030d777e6ec0e0443627c51cecffcc55e41d43b0b8edd40d1",
 					"hours": 3102,
 					"calculated_hours": 3102
 				}
@@ -3176,6 +3246,7 @@
 					"uxid": "a1ed39cded6d9a0605b52f25cbedb363e57a168d1ad1d1db437816a401c061ab",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "732400.000000",
+					"src_txid": "b9a795552bec1a722718b44a08ad152656242b1d23afb53d2247b3016d920b7e",
 					"hours": 387,
 					"calculated_hours": 387
 				}
@@ -3219,6 +3290,7 @@
 					"uxid": "f89c968840831d03abaf3c41cf8a405e4b4ddbfb19f5ba300a8ea8e4dcb1d9a4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "731400.000000",
+					"src_txid": "fc02772662176c282c2b6538732d3d6eb1399f006a0b52e64d07fc104038f638",
 					"hours": 48,
 					"calculated_hours": 48
 				}
@@ -3262,6 +3334,7 @@
 					"uxid": "36972dc046829caa340eaecbfeb42f4174bcdecfb87296d56503e5fb10e9de8d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "730200.000000",
+					"src_txid": "9880bebc51471e0b3c520920db836d674f652503314cd74069a59ccad0d0967a",
 					"hours": 6,
 					"calculated_hours": 6
 				}
@@ -3305,6 +3378,7 @@
 					"uxid": "6962c7c1fcc98f532a9003990163bb251811a4700257968a641b1fe975cfc51d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "729200.000000",
+					"src_txid": "578075959959db70ae86f4f60d2ae3ff245727d086eef86ed80db5e1c7c9fbaf",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3348,6 +3422,7 @@
 					"uxid": "d53fae3b48bde2d1328964a2e7f42e8e833983db159ba30f627926dea0db7df0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "728200.000000",
+					"src_txid": "de45a24c9c32f808a3d928f30ba8e1b6ef8117a7c0b7a5d616734d9b121d0c30",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3391,6 +3466,7 @@
 					"uxid": "228794e6b3eb69aecc5334e140afbad22883326dcf229bd3092f238ed9ec800f",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "725700.000000",
+					"src_txid": "16f8b9369f76ef6a0c1ecf82e1c18d5bc8ae5ef8b01b6530096cb1ff70bbd3fd",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3434,6 +3510,7 @@
 					"uxid": "6efc30b4c943ba4de8d2c89901a0b2a4d9a0ecf34713917eae37c6debca616ed",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "724700.000000",
+					"src_txid": "030177271beee04f1a0974d0c5042f07c7ca1db1c5d496fbee3c441b1b7c5bee",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3477,6 +3554,7 @@
 					"uxid": "6c8b1ba9dc7e8900b42d55e9fbe6ea0e00d7eaccf67a7b66c0a2b771cf88ea05",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "724200.000000",
+					"src_txid": "57150aecde96bde972183b9b0d7d27dda2c0179fb71630e92c27856d211335cd",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3520,6 +3598,7 @@
 					"uxid": "59d44fefbe86ebae4118dee90609d6a1c08c36f259c65e3fad63b9e41c37bf0c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "723200.000000",
+					"src_txid": "3bb9fc516dc2c522e28f99e6833253863c550547ce0e0a2dd963a0118b7a44a7",
 					"hours": 0,
 					"calculated_hours": 9192675
 				}
@@ -3563,6 +3642,7 @@
 					"uxid": "5baf8c8ab1a01d80a6f496144815cf6bda5289b34055010e21324ea3950d3299",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "722200.000000",
+					"src_txid": "5701965d326520f86335da87c6d1781fd49f1e66520b94e1783711eba724f482",
 					"hours": 1149084,
 					"calculated_hours": 1149084
 				}
@@ -3606,6 +3686,7 @@
 					"uxid": "dd07d759d92e3d628a35c467dcd919dcae825a9fa79a14855714270dae08c0ce",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "721200.000000",
+					"src_txid": "3fae944ef07d9bcba1bcbc8bde87da50a1232132074803f8442deb563ed2da51",
 					"hours": 143635,
 					"calculated_hours": 143635
 				}
@@ -3649,6 +3730,7 @@
 					"uxid": "c739b518f3f700e810f81523d81b15f968fbf202f389ceaa9d9f303319a00275",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "720200.000000",
+					"src_txid": "79681167a7681edecb998e4a6dccdd0b7be45f163c8f6db23436517936269fb8",
 					"hours": 17954,
 					"calculated_hours": 17954
 				}
@@ -3692,6 +3774,7 @@
 					"uxid": "95694746f813d018be7988aec666b52924a7815adabe9cbdac3f6ab0f51bd1ab",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "719200.000000",
+					"src_txid": "b69536fbec9911da41e9d0c5ca73459f5e692ba155f8b72c0972792e9937a0fe",
 					"hours": 2244,
 					"calculated_hours": 2244
 				}
@@ -3735,6 +3818,7 @@
 					"uxid": "be958e5c47415291a781648335db24e448e1f4f09aa5e9c3f055fbc906b574d7",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "719100.000000",
+					"src_txid": "3e228564e3c187e22bd489857fdb1db7036021e19f688aad56cfee57d5e13ac5",
 					"hours": 280,
 					"calculated_hours": 280
 				}
@@ -3778,6 +3862,7 @@
 					"uxid": "68165429853e18e4414ec6c15630262ebcaa802ff1d83b6cbe116db51cb32066",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "718100.000000",
+					"src_txid": "18607765c3fbd45eafa15d2d62ab3cbc7ba7bd80c42931aae4db75aa02898671",
 					"hours": 35,
 					"calculated_hours": 35
 				}
@@ -3821,6 +3906,7 @@
 					"uxid": "46aeb9ea01bb04e28c55ef11f8e75434dbeee546f7e06bdef332c604590c48a1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "717100.000000",
+					"src_txid": "dc10e0565a14dfecda066577581f3e2d073de34ed3e911ed94413d38fc0a33d2",
 					"hours": 4,
 					"calculated_hours": 4
 				}
@@ -3864,6 +3950,7 @@
 					"uxid": "598503902d2e6cb62d6f6478f09d8da05af6fd2da92b50825da3b7f74b2df34c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "716100.000000",
+					"src_txid": "b0d7ff47658b3e32d8457eb62f6df0c7caaf7feadcbf8cc0c713976026f0404c",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3907,6 +3994,7 @@
 					"uxid": "4b917e7bd3409c43f9f670f2846ce74f9288708df5aa1d9ae142f2411ce426da",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "715100.000000",
+					"src_txid": "be0957035ed2ac444f67273fc5c1c6a39ee373f6f83d1604d0023742a8cd7e42",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3950,6 +4038,7 @@
 					"uxid": "d50a372f8f8cd1e0b10d847613b68ee760f195f5f212d6c59e86312c84dd07ac",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "714800.000000",
+					"src_txid": "c9582c8134fa64fdf08cd93d42035adcced3f16aa8ee1a1393e3fcd7c07aa40c",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3993,6 +4082,7 @@
 					"uxid": "896865f9b610f9fb69a741596b3ecb9fff3790d40476a9f7852831bdf477aaee",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "713800.000000",
+					"src_txid": "29a883ef9dc67bc683014187b9865c827b5e2f8afd7bf6f3787483318063789e",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4036,6 +4126,7 @@
 					"uxid": "272d5bbd86a87796a20e3e4debc46a2076718800343bee4f72fc0217a98a10a3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "695800.000000",
+					"src_txid": "c3fd04cd27ea311b1a67d40cd3dbb2ea8ae2c6f6139620cb86be29f33ed99171",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4079,6 +4170,7 @@
 					"uxid": "60906201d3e7c67ddb976972460b2b8ed093e1f6720a784cbaea376ca13e6cef",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "670800.000000",
+					"src_txid": "3d9f1aa1b6206275081cb9c26155f6261be1ef9c94b4eaadb1a7e8277a2099fa",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4122,6 +4214,7 @@
 					"uxid": "4912e9dbbb5a4cc7472c27b0212ab443e7b5499207b10666a66257005e182714",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "664464.000000",
+					"src_txid": "d720ca0efb19b964f481724e5d3f932841e9e75a69b998baf4b575cf3298cb87",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4165,6 +4258,7 @@
 					"uxid": "659bac1636b64087ad5d3cb0ae78c52f28ad920016ec67e08415a537e0343072",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "663464.000000",
+					"src_txid": "0e8e352b1f2cd419bca619918ce6d5ec1eac0ba7252d76eef5d9d8f8186f737a",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4208,6 +4302,7 @@
 					"uxid": "97f64c3c636e5fc997e277cd48644055ef51045ed9c473c05dd6e699872a6c3d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "662464.000000",
+					"src_txid": "d5091ca65ff61998dfb4535a7927fb736abf2a81140a11322dcf8226de27cf92",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4251,6 +4346,7 @@
 					"uxid": "122b7a9a61ee04e071002d74ffb26b12ed7952ff9a138b5437f990f4678cc2e5",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "662314.000000",
+					"src_txid": "30e66ff45cfb145eb465e2ebdef0bb10005138bc1727c83888785b04d548e85b",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4294,6 +4390,7 @@
 					"uxid": "c07593d4329f82da243e4bbd7430e4b10e7b35f9ce0a3718d0e6d25d20b4939b",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "661314.000000",
+					"src_txid": "ec79854fade530d84099d5619864a8e1e8ec9d27a086917a239500cada43c6e8",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4337,6 +4434,7 @@
 					"uxid": "4d52106e41dba0099549fd81fb8feb6915225b0125c53faa0f7c578ea78f213a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "660314.000000",
+					"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4380,6 +4478,7 @@
 					"uxid": "fef9dd3b633274743099e607d9229717a001d6de6a4031479cc30d31d65e8396",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "659314.000000",
+					"src_txid": "3991a257eee265481e713917a3a9c15756f61175bcfc7acfdbe84158e43fd5e6",
 					"hours": 0,
 					"calculated_hours": 269219
 				}
@@ -4423,6 +4522,7 @@
 					"uxid": "21f0fb666dca05d7a43ab26a378f7f7eaedfacde22fa047ca72857e9509cc748",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "659214.000000",
+					"src_txid": "b29222c08f10b8bc4ea18981519a3b0e02b9c9cec63ee28d9ffa2efcaf2a8e5a",
 					"hours": 33652,
 					"calculated_hours": 33652
 				}
@@ -4466,6 +4566,7 @@
 					"uxid": "6b3a0cab1d9ad6fd011a3bac5e6ff4e3f7903bce911dc7fe83926eae557c34c3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "658214.000000",
+					"src_txid": "50fc81b0ba25669105a169a969459ccdb10278051b604a3f91467c2528c83652",
 					"hours": 4206,
 					"calculated_hours": 8113036
 				}
@@ -4509,6 +4610,7 @@
 					"uxid": "372703f8109295f0f58fbee58795979e10dd887869f4fc1da4881ce8a3c0aeb4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "647750.000000",
+					"src_txid": "fb495093f2f4e5c6555c50150ea60c0a6f430e53aa971ebb3e2b5412866a1f06",
 					"hours": 1014129,
 					"calculated_hours": 1019526
 				}
@@ -4552,6 +4654,7 @@
 					"uxid": "14027340f6e1d98bba3f7f5f3b50e3588f8a19e4d021db944e7a28b2643640e1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "635750.000000",
+					"src_txid": "a7665cec98224150968ec1ef9ef2d6b3175c9de8f9f8c7bc786b30cc74997c57",
 					"hours": 127440,
 					"calculated_hours": 146865
 				}
@@ -4595,6 +4698,7 @@
 					"uxid": "8e55f10a0615a0737e6906132e09ac08a206971ba4b656f004acc7f4b7889bc8",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "625750.000000",
+					"src_txid": "9364ed6cfcc289df74dc6bac1993f7ab3441b898cb3f06918198d2476c83dbac",
 					"hours": 18358,
 					"calculated_hours": 44173190
 				}
@@ -4638,6 +4742,7 @@
 					"uxid": "fe6762d753d626115c8dd3a053b5fb75d6d419a8d0fb1478c5fffc1fe41c5f20",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "615700.000000",
+					"src_txid": "f58f664eea258100126636a4111838e489ef5aec848ca8498319c290fa2a0805",
 					"hours": 5521648,
 					"calculated_hours": 45730107
 				}
@@ -4681,6 +4786,7 @@
 					"uxid": "8f9c09c37e0c636178e4229e2e8212c067ef0a8c501be9e2757a97b980d7a98a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "605700.000000",
+					"src_txid": "701d23fd513bad325938ba56869f9faba19384a8ec3dd41833aff147eac53947",
 					"hours": 5716263,
 					"calculated_hours": 33911093
 				}
@@ -4724,6 +4830,7 @@
 					"uxid": "d620b98b74f27e2afc0fcd750037de5d157666d2dae15817348059d23ec97f52",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "565700.000000",
+					"src_txid": "a230d5b5b745bb51d40e86b11e6508dc84a486f5ffd3584b0d45818ab8520802",
 					"hours": 4238886,
 					"calculated_hours": 146017605
 				}
@@ -4767,6 +4874,7 @@
 					"uxid": "30e062105d7ef8c4981932d80d904bee2270c238bc36a6532a8917cce05f17b4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "565100.000000",
+					"src_txid": "655651b51d288fae2ca80dd8231fbc8927e7f0203d698bdf0dc47e1e9c63652d",
 					"hours": 18252200,
 					"calculated_hours": 22329082
 				}
@@ -4810,6 +4918,7 @@
 					"uxid": "32463caca7ea96e2fb3fb03502b29513bb9e6385cb6097c4ba411ea808b6e5e1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "564100.000000",
+					"src_txid": "cff22d57daf828015489bba3b01538369f5627cc89ad0f139261bb0be0dac4a8",
 					"hours": 2791135,
 					"calculated_hours": 2791135
 				}
@@ -4853,6 +4962,7 @@
 					"uxid": "3fa8d60e34b1195ee24fde2c4594b8c0eaf06cb114b395bbce6bebeeccf709b6",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "561700.000000",
+					"src_txid": "1b83454b4e61348b9c643815c26350b4e34796170593895961f329a759cbadf8",
 					"hours": 348891,
 					"calculated_hours": 339572471
 				}
@@ -4896,6 +5006,7 @@
 					"uxid": "ac638ce4f15f749b3ef4168fed59a9ae0e8b5f8894b27b151fae31af102d245a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "561600.000000",
+					"src_txid": "fa7a60f6d4a22404e28ce9d1600442c19237552d8678bd610793cb8e6b3353d4",
 					"hours": 42446558,
 					"calculated_hours": 42491798
 				}
@@ -4939,6 +5050,7 @@
 					"uxid": "6d453ceff872a65be937598159fac754390c00e7731cc73c72169c476d1625c5",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "527520.000000",
+					"src_txid": "b18ed75097ed7910315e3be9042c0ca0b734d30a1afb8f9346bbe18acddd3a8a",
 					"hours": 5311474,
 					"calculated_hours": 5311474
 				}
@@ -4982,6 +5094,7 @@
 					"uxid": "6c34016037cd17622846e71bc635914d4d8f256c147aa5a0b84a896e83229480",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26400.000000",
+					"src_txid": "491130fc9f69d101df220116356e82e2ff21dac1167e6da81c95dd4cc417b3d9",
 					"hours": 64785,
 					"calculated_hours": 62781681
 				}
@@ -5026,6 +5139,7 @@
 					"uxid": "bd9c90d1c11fd00392db236d4c7fc06da07806c1676e4cc6df25c9df35e75d9d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "527220.000000",
+					"src_txid": "cd6fae6c021e64768cbb2e0a17ec6853db94b5dde52b417f872371dc3c24a27f",
 					"hours": 663934,
 					"calculated_hours": 451028438
 				},
@@ -5033,6 +5147,7 @@
 					"uxid": "50e534ebc9c3f0b99461ad70b01d415eabfc046e824a5d1ba46854c913928612",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "1000.000000",
+					"src_txid": "2e05ca5b53cdaf3d65102aa6a4a707a324e5bfa7fa46e9b3b7328d1e0363822a",
 					"hours": 7847710,
 					"calculated_hours": 8202023
 				}
@@ -5077,6 +5192,7 @@
 					"uxid": "44233d76c4cfcf6d45efd339ea004c41a3c21f5e9b1919484f4256c53e8aa5a7",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10000.000000",
+					"src_txid": "5a348a2f9d4e70f1f0d68fa9abc66d8eb4adcd45942c89d79a4121033e7dfc39",
 					"hours": 57403807,
 					"calculated_hours": 57403807
 				},
@@ -5084,6 +5200,7 @@
 					"uxid": "75323e65eec723bb62819835a2e9ae9d7aff770fcf076dd0325e03abec471bb9",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "518220.000000",
+					"src_txid": "5a348a2f9d4e70f1f0d68fa9abc66d8eb4adcd45942c89d79a4121033e7dfc39",
 					"hours": 57403807,
 					"calculated_hours": 57403807
 				}
@@ -5127,6 +5244,7 @@
 					"uxid": "7d9bc531b7a990d565c3f8d64de6861a2c619c80ad5014685548261fa13c4b78",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "528170.000000",
+					"src_txid": "e91d2553c18538d90847e7d432c75978abb0f6f84edeea2f942d018e7306074b",
 					"hours": 14350951,
 					"calculated_hours": 14350951
 				}
@@ -5170,6 +5288,7 @@
 					"uxid": "e07733e150eee8faacba13e00b2719618f44c57311881b450eff03a8a7fad882",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "528120.000000",
+					"src_txid": "71f762590ff2ca5e0591405ca5bb81aa2540981ea6e5cb71da1b30e4f91124a0",
 					"hours": 1793868,
 					"calculated_hours": 1793868
 				}
@@ -5213,6 +5332,7 @@
 					"uxid": "ad55899c8170d5a577e2a501698002d83dcbf46a72ee351c1f45b366e91ec29c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "528070.000000",
+					"src_txid": "8ca1a46e2ea862c0886adccc211140ff394315c580a8f2da711eeed39d6326eb",
 					"hours": 224233,
 					"calculated_hours": 224233
 				}
@@ -5256,6 +5376,7 @@
 					"uxid": "daf47014d9191ccfe8bc920aed20088f40c404dbf1836596f021bdd65bdf3467",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "526970.000000",
+					"src_txid": "ac0737f4a51a7274f6a32f337d21af0681eff77276f6365c1809a1a73564e850",
 					"hours": 28029,
 					"calculated_hours": 28029
 				}
@@ -5299,6 +5420,7 @@
 					"uxid": "8421f4591fa459bba5bb36d8e3465253ae6fa8ce66682a50bbab92bfeb0eac5f",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "526920.000000",
+					"src_txid": "26746e5734590a1ef50f6d8ec6f58c25ed4b2bc57324f9e321f5543807f8830a",
 					"hours": 3503,
 					"calculated_hours": 3503
 				}
@@ -5342,6 +5464,7 @@
 					"uxid": "fa71bd8cc9a8ec39da2b9eb1d6f50d1c79f3c527e0feb4a121c87a82a337106c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "526870.000000",
+					"src_txid": "4553ac3bd00bc61bb9deb8a2bf3c606ecf78b857da710728f5b86fdd20434958",
 					"hours": 437,
 					"calculated_hours": 437
 				}
@@ -5386,6 +5509,7 @@
 					"uxid": "61d2b0b56b48f446cde90400e87ecd005c555ccc376bbc08208b682c4bafe937",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "511870.000000",
+					"src_txid": "ca448d0b9f00c3f779acd75ea6e5d09cb93b4dee8ae417e43cecc58b121155f2",
 					"hours": 54,
 					"calculated_hours": 54
 				},
@@ -5393,6 +5517,7 @@
 					"uxid": "bc2efd372485b52b954f4bde244c776af12529ba1382ee3e343087754365c3fc",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "15000.000000",
+					"src_txid": "ca448d0b9f00c3f779acd75ea6e5d09cb93b4dee8ae417e43cecc58b121155f2",
 					"hours": 54,
 					"calculated_hours": 54
 				}
@@ -5436,6 +5561,7 @@
 					"uxid": "18ffebf7d8410a48f00b6bbfa5272ba374c0b70c6c31172975b4c503542d4193",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "25390.000000",
+					"src_txid": "ed7b53620a019b1a4f63d84680c1fd72f411273a944c59a7b437aa014c351c88",
 					"hours": 980963,
 					"calculated_hours": 5031486
 				}
@@ -5480,6 +5606,7 @@
 					"uxid": "f0521d23d6178c3bcf37bbf9755c5e6fc286ae286908fd970bba69fd44cd4f1a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "526093.000000",
+					"src_txid": "688395456432e777e9bcef2482950d047259da990199d26d88f113ba37e870e6",
 					"hours": 13,
 					"calculated_hours": 24116992
 				},
@@ -5487,6 +5614,7 @@
 					"uxid": "b20f489859a7f5236c3cdb5ed9ed7b49fb086622e251c9c73bced00d4de84648",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "1000.000000",
+					"src_txid": "036ad7678b828002f9f75645cd66e8c4a2d2ef66d4866bf7cfe5797be691a648",
 					"hours": 628935,
 					"calculated_hours": 665623
 				}
@@ -5530,6 +5658,7 @@
 					"uxid": "cfe2c8e49c9de33d4a589a1413f125c6e297aa4c65c220cf3cb14d77ad399950",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "514593.000000",
+					"src_txid": "768dc6803457ca6ba774e251f0a8f482d8f7134a5a8347831ae1d84ff39040b3",
 					"hours": 3097826,
 					"calculated_hours": 3097826
 				}
@@ -5573,6 +5702,7 @@
 					"uxid": "621e724988e58bf27ec29a910b7a53ed028ee2185a77e727f5612be31886b658",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "514093.000000",
+					"src_txid": "60ba5bab66295f08c5c96411f53bdf38bdf2b985b6dec3989b7754a8e2919ef8",
 					"hours": 387228,
 					"calculated_hours": 387228
 				}
@@ -5616,6 +5746,7 @@
 					"uxid": "4e421d6b25d84e7bfb4561465e15867cc751cd2527e99901f5afc538a344ee57",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "513793.000000",
+					"src_txid": "8839c0de129a84bb3025f8e314dae4d331b0da6a446a9893ad11225eec650e5e",
 					"hours": 48403,
 					"calculated_hours": 48403
 				}
@@ -5659,6 +5790,7 @@
 					"uxid": "899150e09c28e157df0548f505d6ede097274c9ed69b269085d03c0582141d81",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "512793.000000",
+					"src_txid": "6cf290b9b63988d6126b6101c10992f6d9340988731e67867f011790f1fdf8de",
 					"hours": 6050,
 					"calculated_hours": 6050
 				}
@@ -5702,6 +5834,7 @@
 					"uxid": "1df6bca39e9eb5491a5cc5c5960277e5da2d3eb7dcba02346a88b8097e9f85cb",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "512743.000000",
+					"src_txid": "8ca9114947a591d12c8bcb3aed6c2b6f6f50c13ebea44fe62fcfd783b4716166",
 					"hours": 756,
 					"calculated_hours": 756
 				}
@@ -5745,6 +5878,7 @@
 					"uxid": "7d72885b66c4b55fa019a084fe867ec0133ccf69a47dc007a6063a98235f2c0c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "500243.000000",
+					"src_txid": "6b056847543ff37d8dbb7506d85514b3e18001ce973b7aac2a1a198a7f3be318",
 					"hours": 94,
 					"calculated_hours": 94
 				}
@@ -5788,6 +5922,7 @@
 					"uxid": "273800d205c2cde0dd2bdd7d942a394108479e1d0fe7c2d665044f078ee654eb",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "497843.000000",
+					"src_txid": "7732aba0b8f9773c975158578159f5f6e98e9864d1cd2b0cef23cac03783cb99",
 					"hours": 11,
 					"calculated_hours": 50279388
 				}
@@ -5831,6 +5966,7 @@
 					"uxid": "a7ae18a9ac1e1787fc13d28cfb6de19711ba19a6737a66aaf29d1577e967c4f3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "492843.000000",
+					"src_txid": "c8cbf96c9875e5a7f9f20cc301e9541f41182ac02747953f299d97a971e861e8",
 					"hours": 6284923,
 					"calculated_hours": 26076676
 				}
@@ -5874,6 +6010,7 @@
 					"uxid": "78523dd46614ec8b6aead939096a0dc77580475ff4ef6029cf15cc6af6121b4c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "491843.000000",
+					"src_txid": "7c2da40e69c1ab57129cda200cbc4916fc67673436209b549c0496a4991f73be",
 					"hours": 3259584,
 					"calculated_hours": 3259584
 				}
@@ -5917,6 +6054,7 @@
 					"uxid": "92b97e2593356de140619f723ff1dceeb586ddc074c6d28b638ee21a6c545558",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "491743.000000",
+					"src_txid": "6638eac25e01cb7aabc20e0bd8fff66267bfa88ef4d3b021cda4248f6c8538a3",
 					"hours": 407448,
 					"calculated_hours": 394767303
 				}
@@ -5960,6 +6098,7 @@
 					"uxid": "ad23f4d4cfba4a4f531a072bac6b7f3b5002ca97f3bc8a6064d556f404df197c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "479243.000000",
+					"src_txid": "22b65c63f88e188f8da71f42e41102cde030d9550cfc990b4391e0339a4cb2dd",
 					"hours": 49345912,
 					"calculated_hours": 148245426
 				}
@@ -6004,6 +6143,7 @@
 					"uxid": "1a736e8db443d47be27b5772d3d7ef80afd09c5f44bffe2390056e2ba0378679",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "500.000000",
+					"src_txid": "bc35493562cbe89797ce21a6202c8b43fc8514910ccb197c2f971c624b1fa5dd",
 					"hours": 18530678,
 					"calculated_hours": 18530678
 				},
@@ -6011,6 +6151,7 @@
 					"uxid": "5405881c286f02327718b8124e1b421123dfe3905fe60b2272ffe7632f4102e9",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "478743.000000",
+					"src_txid": "bc35493562cbe89797ce21a6202c8b43fc8514910ccb197c2f971c624b1fa5dd",
 					"hours": 18530678,
 					"calculated_hours": 18530678
 				}
@@ -6054,6 +6195,7 @@
 					"uxid": "f98bd5645556fc85678355430dcae91b13bb48a257e51fe4c94565bb450aab3a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "478243.000000",
+					"src_txid": "32c585c56c5879158e3075f299998f6cf922b06b9620f272ebb4cb4a2353d4eb",
 					"hours": 4632669,
 					"calculated_hours": 4632669
 				}
@@ -6097,6 +6239,7 @@
 					"uxid": "019d3c48e4f48ae4c7d2c60ba8ba3d6a821cd1f34cc8d7dcae0e99e448aea268",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "476243.000000",
+					"src_txid": "97ed144d626d0ff6fca09745735aec22a103d182971a45989500a3aa757358d4",
 					"hours": 579083,
 					"calculated_hours": 579083
 				}
@@ -6140,6 +6283,7 @@
 					"uxid": "4cac2776f179bf3b38d862158871a117bde8ca8bd3185490861138b4862ba997",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "456263.000000",
+					"src_txid": "b5ffbbb48c9900feb663f79c3b3e1c89328a08b592f96071fd4d3171197a5ff7",
 					"hours": 72385,
 					"calculated_hours": 72385
 				}
@@ -6183,6 +6327,7 @@
 					"uxid": "9eb9840cfe5e9c546b2db592420d4651433a6913eb46a50500834fcde4989af2",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "455263.000000",
+					"src_txid": "981c2bb64f9e6717353cad40e21f3e97bd188381fde77862298488a516c31252",
 					"hours": 9048,
 					"calculated_hours": 9048
 				}
@@ -6226,6 +6371,7 @@
 					"uxid": "a6624db7b164d43f52d38f9584a7e79377e46077ee23823b61a53948678e28e7",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "450263.000000",
+					"src_txid": "4edf7e4859bd537481164719a563af45b2603d2caf1b676d6fe1e08713b0d6f3",
 					"hours": 1131,
 					"calculated_hours": 1131
 				}
@@ -6269,6 +6415,7 @@
 					"uxid": "36a9b21493d059479a71e7f0cffc8b9a920d572eca50b73483e64dc7facf087a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "437332.000000",
+					"src_txid": "76b704d474896c5a3179b45a48c3ad327d5ebc27a6681ea7f514a90ba625bac3",
 					"hours": 141,
 					"calculated_hours": 141
 				}
@@ -6312,6 +6459,7 @@
 					"uxid": "23bdbe3b210b25da017917ea4345d589adea792ad156dcfd875a55d9509bbe5b",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "434832.000000",
+					"src_txid": "8ecc2fb1efa47e6ad0c4670281b364a2828bfe86d59fbc14105c5b3a3c34fd17",
 					"hours": 17,
 					"calculated_hours": 54601629
 				}
@@ -6355,6 +6503,7 @@
 					"uxid": "5ec2fea3fa7c2b44b2c2b0dfc8b3085d091eb6b6a9bb2d3330a7c6ff57bd61de",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "433832.000000",
+					"src_txid": "2c97923aba19d8846f8f90db6dc89da7d433ead3ea8dc3155294ab4c9e7e61a4",
 					"hours": 6825203,
 					"calculated_hours": 15623556
 				}
@@ -6398,6 +6547,7 @@
 					"uxid": "8ed671db62d7a541aebcfcbdf4e677d9d5c49979e3dfbc94e532b32b9273b4cd",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "333832.000000",
+					"src_txid": "7c3f991c9cb5098648da480666613a048267678dcf7033c6138b0ac619003bcb",
 					"hours": 1952944,
 					"calculated_hours": 24019239
 				}
@@ -6441,6 +6591,7 @@
 					"uxid": "af7420cde3eec0f8ca1b1aa5bc6c47c89055877be61863a50e0665ee4fd2d737",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "333732.000000",
+					"src_txid": "4c41f200b398abbba12cb9ad5b935a5dad3bb6283093f062c82ae7c7904747a5",
 					"hours": 3002404,
 					"calculated_hours": 3002404
 				}
@@ -6484,6 +6635,7 @@
 					"uxid": "621e418133fa0e18013978ea4cb8d8de33d00174d5f41ef11c8750a178b20cd3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "283732.000000",
+					"src_txid": "6778a6900cf26b0ad69d2ead927663bd2bbaccd9b97d0dffb74655a08757ee5a",
 					"hours": 375300,
 					"calculated_hours": 375300
 				}
@@ -6527,6 +6679,7 @@
 					"uxid": "eacaf7455ea2fb2a028fe670f7bb578c4c1ca767cea247ebfc7e3fecd8f1d5e8",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "278732.000000",
+					"src_txid": "99988a504cb60473ad8b5047a9be9049dff3dd2ee13879707a12736ed52ea9a5",
 					"hours": 46912,
 					"calculated_hours": 46912
 				}
@@ -6570,6 +6723,7 @@
 					"uxid": "7802f51a5010ce9397a73aabe79ebc1c4ad4bb79f1352cf01064f7657d392079",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "278232.000000",
+					"src_txid": "714a3b2ba4479d0a95ad0ebae11bc1198eabc6392dabe776c15e7a68e0d82cf8",
 					"hours": 5864,
 					"calculated_hours": 5864
 				}
@@ -6613,6 +6767,7 @@
 					"uxid": "bb95e005de46b18783350e39ab6f0f969db253445c99e5b97d172dee6f81a4db",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "277732.000000",
+					"src_txid": "7e8d02180c5e49cd36b545c8986ffaadc7e90840259d3fe10ceaff3e4cd931c4",
 					"hours": 733,
 					"calculated_hours": 218640543
 				}
@@ -6656,6 +6811,7 @@
 					"uxid": "d187d4cd730f2634e9f8bbd9e5a87eb37d1e319dbcc3d8bd9fe07cbf36f04438",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "277632.000000",
+					"src_txid": "7388dab349f2d2a59ab071fc592c0173acfa357f23fd17dae1561089da55e74f",
 					"hours": 27330067,
 					"calculated_hours": 27330067
 				}
@@ -6699,6 +6855,7 @@
 					"uxid": "d75874d45892d08632c1b9ee89f2137c21491a70f95bf7c04b4f0d65e465c3f1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "276632.000000",
+					"src_txid": "5733f006dda42be6198d3fb035170c9160428ad321c8255b851574776e03c34f",
 					"hours": 3416258,
 					"calculated_hours": 3416258
 				}
@@ -6742,6 +6899,7 @@
 					"uxid": "92bc1ce78fd98223f4c27438e22214117952de08798c2c5557f3e3350deee45f",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "275632.000000",
+					"src_txid": "725698203caf11e909360449956f0285735d44f4573c81413852d25b220e61b0",
 					"hours": 427032,
 					"calculated_hours": 30172931
 				}
@@ -6785,6 +6943,7 @@
 					"uxid": "e4cd8349646afcc6fca01e94e0e247a22d447d0a3e6bef728854ebf3fe0a1507",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "275631.000000",
+					"src_txid": "823a284da9b7e49180e599552e824c60c23d28cc9fd4915e57037ac6ba5e364f",
 					"hours": 3771616,
 					"calculated_hours": 113403922
 				}
@@ -6828,6 +6987,7 @@
 					"uxid": "46eec2ffbdaa24e27231765678002ee7c9ac4aeea7bb6df14f66bfa957e58d1a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "274631.000000",
+					"src_txid": "ccf809db24bde3af9083bb6ba590e91f71cd93335c945ccae3f815ef68994843",
 					"hours": 14175490,
 					"calculated_hours": 24339125
 				}
@@ -6871,6 +7031,7 @@
 					"uxid": "a0ba6219e79ab6470430b6b387602b58c96ef57a850e9dc94af8da0dfedfcad1",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "25314.000000",
+					"src_txid": "b62e6cc6b88c160a1716d08989bc7ac492f52a7b9fac7922ef2477677064abc0",
 					"hours": 10499712,
 					"calculated_hours": 30601622
 				}
@@ -6914,6 +7075,7 @@
 					"uxid": "207fcc6aa056e56256b21b73410f679d7e1e1af414e95891e23cd689affdefb9",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "24314.000000",
+					"src_txid": "c97bf2e161844d70686539eaec694b32678b130539946af8c3ec36f905e47d9a",
 					"hours": 3825202,
 					"calculated_hours": 3825202
 				}
@@ -6957,6 +7119,7 @@
 					"uxid": "b636238d9d3c0eba57aeb47daa7a23bef5aac4021b636568d56c8428f62c6827",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "23314.000000",
+					"src_txid": "7ca2667f49dc21f893f2273c592618b0238959ec9aecc881150d6507c6a1755e",
 					"hours": 478150,
 					"calculated_hours": 478150
 				}
@@ -7003,6 +7166,7 @@
 					"uxid": "d13c10539700b17635d5ca63adb79f7da7faaab1d1c415fdf68e9a70ed5c633e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "273631.000000",
+					"src_txid": "e348450f03f57e10e3cb1227b6874186d72f090c1cb6468b400b4906807cef02",
 					"hours": 3042390,
 					"calculated_hours": 112708374
 				},
@@ -7010,6 +7174,7 @@
 					"uxid": "059f33c1a1a9e33c2518a6ea915534d5093f8aaec9b1c69a82e5348dcac52f6e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "1000.000000",
+					"src_txid": "c97bf2e161844d70686539eaec694b32678b130539946af8c3ec36f905e47d9a",
 					"hours": 3825202,
 					"calculated_hours": 4225310
 				},
@@ -7017,6 +7182,7 @@
 					"uxid": "c91cd337ffa1a0e7d09ecd3c2f74c2932a5b7d9266b2e85205f64e5a7e8c5426",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "1000.000000",
+					"src_txid": "7ca2667f49dc21f893f2273c592618b0238959ec9aecc881150d6507c6a1755e",
 					"hours": 478150,
 					"calculated_hours": 878252
 				},
@@ -7024,6 +7190,7 @@
 					"uxid": "886eaf65af6434d07ca20fd4789825bbe87a61ff633fe1df15b69b9024b3cb99",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "1000.000000",
+					"src_txid": "ccf714517563cfb8a9d694a7a0ac534da01cb74e18d8a9cd0d410081970d8015",
 					"hours": 59768,
 					"calculated_hours": 459854
 				}
@@ -7067,6 +7234,7 @@
 					"uxid": "7cf5efd1f59555771e82dfbf11047cd856e554daac323e8224c174796b58cef1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "275631.000000",
+					"src_txid": "7a05ca15c9860700b34642339e91427ce0b211a8fe14805751d730f8ca0e5363",
 					"hours": 14783973,
 					"calculated_hours": 14783973
 				}
@@ -7110,6 +7278,7 @@
 					"uxid": "00813b3eebc56b3269dc82324b708ed031f816276eef23d2ec4dbaed0fe6be68",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "265631.000000",
+					"src_txid": "9da07bf85e25c466daeb9e4bb8825161e2f2eb60ce470fecff30a557d8ab8d58",
 					"hours": 1847996,
 					"calculated_hours": 94857214
 				}
@@ -7155,6 +7324,7 @@
 					"uxid": "22f6cbb46c9d8566f6cdb3882dbd77bc473432c097b704c14457babd66da993d",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "400.000000",
+					"src_txid": "410bccc66563821a8382f2dd028ed9c589dad28201d59ea27a677b6d79a73b3e",
 					"hours": 3128290,
 					"calculated_hours": 3397714
 				},
@@ -7162,6 +7332,7 @@
 					"uxid": "d0e6c3ff06b1125d70a707f57b4888a96aa56fe26fbf0fc80ce7d560acc77f63",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "400.000000",
+					"src_txid": "18596ed63d195d0ac3e75dbbd055d0a20dfb08ff5f501b0f2a1140fcb519bc00",
 					"hours": 27225,
 					"calculated_hours": 489283
 				},
@@ -7169,6 +7340,7 @@
 					"uxid": "b220185a9f0f1a6af34e4b1ad882b7634d2fe9db3d1f8d7fdbc0815856abc06e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "244831.000000",
+					"src_txid": "c0b00aa1fac000b225f3d59983d7be04b41dded7e70549cd118648c0f4120622",
 					"hours": 11857151,
 					"calculated_hours": 258504661
 				}

--- a/src/api/integration/testdata/address-transactions-incoming-212mwY3Dmey6vwnWpiph99zzCmopXTqeVEN.golden
+++ b/src/api/integration/testdata/address-transactions-incoming-212mwY3Dmey6vwnWpiph99zzCmopXTqeVEN.golden
@@ -22,6 +22,7 @@
 					"uxid": "c07593d4329f82da243e4bbd7430e4b10e7b35f9ce0a3718d0e6d25d20b4939b",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "661314.000000",
+					"src_txid": "ec79854fade530d84099d5619864a8e1e8ec9d27a086917a239500cada43c6e8",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -65,6 +66,7 @@
 					"uxid": "bc513a68461d5c401e65a500baf7dfa163735ef63b817bb7b73c4139d5c29d18",
 					"owner": "212mwY3Dmey6vwnWpiph99zzCmopXTqeVEN",
 					"coins": "1000.000000",
+					"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 					"hours": 0,
 					"calculated_hours": 561
 				}
@@ -108,6 +110,7 @@
 					"uxid": "bffea1990d71311b695b2d343b9f09a216b7a8257c1cdcb01b2ab9459e1490e3",
 					"owner": "jtuSERvfzN3kUYekg8LemCQ5kF5g97N8ZL",
 					"coins": "10.000000",
+					"src_txid": "acfb61f7ca39d5dfe33e8ed66f73ab181da0a3206d457bf055dcc4b9731a3ec8",
 					"hours": 70,
 					"calculated_hours": 70
 				}
@@ -145,6 +148,7 @@
 					"uxid": "fe6762d753d626115c8dd3a053b5fb75d6d419a8d0fb1478c5fffc1fe41c5f20",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "615700.000000",
+					"src_txid": "f58f664eea258100126636a4111838e489ef5aec848ca8498319c290fa2a0805",
 					"hours": 5521648,
 					"calculated_hours": 45730107
 				}

--- a/src/api/integration/testdata/address-transactions-outgoing-R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ.golden
+++ b/src/api/integration/testdata/address-transactions-outgoing-R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ.golden
@@ -22,6 +22,7 @@
 					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
+					"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 					"hours": 100000000000000,
 					"calculated_hours": 100000000000000
 				}
@@ -653,6 +654,7 @@
 					"uxid": "e3e72ee077c8b0c3f87da7cf50cad8876bd3f489f373d9fe82fc2e971df56f76",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "1000000.000000",
+					"src_txid": "86564b421cd3d4fe6f5f2d7a3e5db9d6fc340892bddd3a150533dff7036d0efe",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -696,6 +698,7 @@
 					"uxid": "af0b2c1cc882a56b6c0c06e99e7d2731413b988329a2c47a5c2aa8be589b707a",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -733,6 +736,7 @@
 					"uxid": "0cd548e03bd13bca8647cd13f6baef0c65fd03081aeb6dc3695536e5bc6018ae",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999990.000000",
+					"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 					"hours": 1,
 					"calculated_hours": 5556
 				}
@@ -777,6 +781,7 @@
 					"uxid": "9eb7954461ba0256c9054fe38c00c66e60428dccf900a62e74b9fe39310aea13",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10.000000",
+					"src_txid": "a6a709e9388a4d67a47d262b11da5f804eddd9d67acc4a3e450f7a567bdc1619",
 					"hours": 0,
 					"calculated_hours": 2405
 				},
@@ -784,6 +789,7 @@
 					"uxid": "706f82c481906108880d79372ab5c126d32ecc98cf3f7c74cf33f5fda49dcf70",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999980.000000",
+					"src_txid": "c24b92898381fbebe59a457924184f4cce1e7166e140ca75aea5baf854c1ab75",
 					"hours": 3704,
 					"calculated_hours": 3704
 				}
@@ -827,6 +833,7 @@
 					"uxid": "fa2b598d233fe434f907f858d5de812eacf50c7b3fd152c77cd6e246fe356a9e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999890.000000",
+					"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 					"hours": 4073,
 					"calculated_hours": 6061184
 				}
@@ -870,6 +877,7 @@
 					"uxid": "c603e99ceae4d15c20360714ee07ba6e3a944a97ea9285d164c23252e93958b6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -908,6 +916,7 @@
 					"uxid": "4168b9378363cd81939e667cf78055d35a60d3101f5f9e3d2ae709e3981e29fc",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999880.000000",
+					"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 					"hours": 4040790,
 					"calculated_hours": 4543507
 				},
@@ -915,6 +924,7 @@
 					"uxid": "d9dae1f82177f979b07016a341ed5c281ed6ed8eaa785a8a107ec16efbe541ef",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10.000000",
+					"src_txid": "686db0a8cd429970bb91163033703410d4750c86ba485709fe1a3faabbbb42f6",
 					"hours": 0,
 					"calculated_hours": 4
 				}
@@ -958,6 +968,7 @@
 					"uxid": "8793a3782bf673393a8f909f267f3bfcc713b600460893b571fd55f675ac65ba",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999880.000000",
+					"src_txid": "56e7bd13dc4c6e1cd80aba66a0a9fed650d0646659ac774e3f1b415848755d85",
 					"hours": 567938,
 					"calculated_hours": 567938
 				}
@@ -1001,6 +1012,7 @@
 					"uxid": "ad742bbc7420c08881e6ccf35e34e8472c0dd6386792359aedcfb752ca618c33",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999790.000000",
+					"src_txid": "cff53a059d55f2c90f6dd7ce7de2cc07cbdbd50b25867cba0f41cd0192614d0d",
 					"hours": 70992,
 					"calculated_hours": 3113963
 				}
@@ -1044,6 +1056,7 @@
 					"uxid": "108520145179c00f581d91e273714811fe6e82ee059d65218eea91154ebd8205",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "998790.000000",
+					"src_txid": "a76cd63b71f1f5425941cd567627e1dcdc8c34306a7945ea48755f5a46efb6f5",
 					"hours": 389245,
 					"calculated_hours": 389245
 				}
@@ -1087,6 +1100,7 @@
 					"uxid": "e79c94aa7013c7611901839236b8a1cdf70e8ef7c40b9e33f99359136de981d6",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "988790.000000",
+					"src_txid": "c38b47bd576e3bced2a9309c3df7622064e71177f54020d77193d5cac310719c",
 					"hours": 48655,
 					"calculated_hours": 48655
 				}
@@ -1130,6 +1144,7 @@
 					"uxid": "c65a9e6aa33244958e9595e9eceed678f9f17761753bf77000c5474f7696da53",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "978790.000000",
+					"src_txid": "b56f3e9239da5c5f9bb5ca80226b8454ba36ce6012f8e323a50c9d9c4eb4a834",
 					"hours": 6081,
 					"calculated_hours": 6081
 				}
@@ -1173,6 +1188,7 @@
 					"uxid": "195f5e50b4eed1ec7ff968feca90356285437adc8ccfcf6623b55a4eebf7bbb5",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "969790.000000",
+					"src_txid": "cf4fe76a08e3296b6f6abdb949604409be66574f211d9d14fde39103c4cfe1d6",
 					"hours": 760,
 					"calculated_hours": 3203760
 				}
@@ -1216,6 +1232,7 @@
 					"uxid": "cb8efc0b1082c39258cb6efd59f64d88b36fcb60143c826829fc5f0ed5c0d668",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944790.000000",
+					"src_txid": "df622e8c9dfaed1d7dca83ad7f6d8946bb86b81398bad521d858cbefef8e4688",
 					"hours": 400470,
 					"calculated_hours": 400470
 				}
@@ -1259,6 +1276,7 @@
 					"uxid": "a6061defc41a8a55e37eaf56ebaa1177446f61719b1d5126698e79a6023f5367",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944780.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50058
 				}
@@ -1302,6 +1320,7 @@
 					"uxid": "3b5f72e772ea886dd872b9087395398133576a6561072d5294fbcd04b49e1d95",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944770.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6257
 				}
@@ -1345,6 +1364,7 @@
 					"uxid": "f265bea876ffcfb8cf64df3aca4dae4a8d7f424ff495d91fb322feddb3a7e505",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944760.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 782
 				}
@@ -1388,6 +1408,7 @@
 					"uxid": "e6d9b56e075a6adf520d1ae7fbab9ae06353ae0b93dc8cb17d82cc3628009a50",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944750.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 23715
 				}
@@ -1431,6 +1452,7 @@
 					"uxid": "2df1e88589be43c55d7c6c3dbcbd663fb759b3245eb8d86b0b9cdaa989556aea",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "943750.000000",
+					"src_txid": "d154d8262abbf517c67d529b0fea7cdf097433bd296d5795b17c6379cb1b1430",
 					"hours": 2964,
 					"calculated_hours": 13450
 				}
@@ -1474,6 +1496,7 @@
 					"uxid": "c5150380691c542b9bdf4cf2280ac612e0576c349f99d47d0a03c77eedc48731",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "942750.000000",
+					"src_txid": "61a33b49e97bfe2d5f026bf45fae43a1b9bdf08c60ec8db017da720a69790c7f",
 					"hours": 1681,
 					"calculated_hours": 12156
 				}
@@ -1517,6 +1540,7 @@
 					"uxid": "9bbb8d620aae3efc7c21bb7d6a7159eda441a83e0fef2cd98f8240b38857d648",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "941750.000000",
+					"src_txid": "4aeafd20b9df56ec852a2c257ff1630b9530d8375a4e72f20238ea36835f76d5",
 					"hours": 1519,
 					"calculated_hours": 9366
 				}
@@ -1560,6 +1584,7 @@
 					"uxid": "25ad0d5ae6a1a9bc61c6b9099fb7829111977a59e1183de4227a0a5352555639",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "940750.000000",
+					"src_txid": "29c229c97d27bcaf842a367520e1916fb855921906bddf4a3b0413ad3f11517b",
 					"hours": 1170,
 					"calculated_hours": 11622
 				}
@@ -1603,6 +1628,7 @@
 					"uxid": "acc75d51ff9f18a224d1ca0481917e2a67298de40955711cd97a08f6733b5b6a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "939750.000000",
+					"src_txid": "42227683dd9c149859d0578ab300d8509d513afadf7834fd8ae7a321cc07d833",
 					"hours": 1452,
 					"calculated_hours": 1452
 				}
@@ -1646,6 +1672,7 @@
 					"uxid": "5c1069a3aa6628ed7f9bdb300bec1a7e7ca6fb4645528a8c6a27c167e7dfe698",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "938750.000000",
+					"src_txid": "d803ab903f68f7861cd8eff93b3c097c5b8f6a697ca67bb01e7e645060839fd0",
 					"hours": 181,
 					"calculated_hours": 181
 				}
@@ -1689,6 +1716,7 @@
 					"uxid": "8190fd31c005510d550c8a241b127fad2558c82aed9483fb4423193d5f4429e3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "913750.000000",
+					"src_txid": "3bf485890e91268452dc3136c0b294dc9909b3aaa10b9c936743e6e9b1a56f61",
 					"hours": 22,
 					"calculated_hours": 22
 				}
@@ -1732,6 +1760,7 @@
 					"uxid": "450cd7795bb3625daa99d6b64b9a8786d593bf1cad986d6c2933dae04b74a593",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "888750.000000",
+					"src_txid": "f51e2ce31961b0186e04cc9d78857c3c21d3e2afb25c050d8c1d67d3320fcc07",
 					"hours": 2,
 					"calculated_hours": 2
 				}
@@ -1775,6 +1804,7 @@
 					"uxid": "b44ee00208690c2123989f40edaff0224825afb20ca0952fbd90bddfd3213642",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "863750.000000",
+					"src_txid": "abed13c2a552633d26b5b51c3ac5abf9808756c0203869ed185a7cd673702ba2",
 					"hours": 0,
 					"calculated_hours": 7814538
 				}
@@ -1818,6 +1848,7 @@
 					"uxid": "6060c983054614b8801e405de697c443a1edebd3236582f89f01c6cf6a165c3f",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "862750.000000",
+					"src_txid": "29798149e90f6442489bcc3294f455441a5a401e81491ed06bdc2c850756f0d9",
 					"hours": 976817,
 					"calculated_hours": 1005575
 				}
@@ -1861,6 +1892,7 @@
 					"uxid": "129726406b3101d51ffd5bfca59a501184d6c8ca363be4ef1b8d8bf48a6c70e0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "861750.000000",
+					"src_txid": "0cded82aa3ac92d78e23d2d0d7faf93c675fc9a321ad55105f65b6fca444b1e7",
 					"hours": 125696,
 					"calculated_hours": 161602
 				}
@@ -1904,6 +1936,7 @@
 					"uxid": "05f42f22f5fea4b5cac8182dc2b4f280149c686434c6d4195a119a8d02ab24b2",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "861050.000000",
+					"src_txid": "b7b42b1b29acab0a2328aaf368ec74be49b4d4caf827e82b439ef4d8be976a55",
 					"hours": 20200,
 					"calculated_hours": 20200
 				}
@@ -1947,6 +1980,7 @@
 					"uxid": "4e1a98a72639efa6253a7cbea0f3b499fa24fb88612ad81414d20e46d2b5784e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "860050.000000",
+					"src_txid": "ca51f9d0a19bf326d6dd39a1e4dd240adaaae279411093d4a5b20f54cddabb95",
 					"hours": 2525,
 					"calculated_hours": 21637
 				}
@@ -1990,6 +2024,7 @@
 					"uxid": "33e0c4c9536afffd491fef6294f22ffb0d16902493946a051db0b218728a1c44",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "859050.000000",
+					"src_txid": "bd617ec27c2bea642fad8c153178e11ca08456d752249324e3011f27c845f87a",
 					"hours": 2704,
 					"calculated_hours": 14635
 				}
@@ -2033,6 +2068,7 @@
 					"uxid": "f32f03f28eece9ddcdc488a85100c94a7c924c185ae560363518dae5e2aacccb",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "858050.000000",
+					"src_txid": "0f4958d590ed4ac9aca79d848731b358b1c01fab9717775cf6515f2bf2706dc8",
 					"hours": 1829,
 					"calculated_hours": 94784
 				}
@@ -2080,6 +2116,7 @@
 					"uxid": "2987e7c89d353ad5d63cea2bf2724dc5f7a5ef5fb81f5ea160a307f0726ac2f5",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "9fb039cd90a4e9b85669bd6ef878b98a9e84eec7d4804e2bff6f0dc9c2739c44",
 					"hours": 0,
 					"calculated_hours": 701
 				},
@@ -2087,6 +2124,7 @@
 					"uxid": "a52408daa8ce7026c70b61d4df4212fb577462060f340bfce779225b3e18193d",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50605
 				},
@@ -2094,6 +2132,7 @@
 					"uxid": "dc73aac74348dd285a1456c1fae2204d7c2039d50a765bdaae0c31f7c7e059db",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6804
 				},
@@ -2101,6 +2140,7 @@
 					"uxid": "e4e375b9dc55ff53d6de9120f1a87ff00e00a779835f8320f2c6b3090d0466e6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 1329
 				},
@@ -2108,6 +2148,7 @@
 					"uxid": "d11b05345917d171f60c31bd2634041b73b97eae364724369ddb8d53369397fb",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 644
 				}
@@ -2145,6 +2186,7 @@
 					"uxid": "6002f3afc7054c0e1161bcf2b4c1d4d1009440751bc1fe806e0eae33291399f4",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "27000.000000",
+					"src_txid": "0301358c2db5314ca43c442bac3c1daf31f4b39f9ac9e22dc157687212cab703",
 					"hours": 220,
 					"calculated_hours": 823240
 				}
@@ -2185,6 +2227,7 @@
 					"uxid": "99b4e51e1afd04813656e6202c7e462d88ce87ba980da7a62591190d72d1073c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "858000.000000",
+					"src_txid": "fe01250cfdf84eb0182c033c216891e7e6971cc85976c4c46d9e3c608974d233",
 					"hours": 11848,
 					"calculated_hours": 962798
 				},
@@ -2192,6 +2235,7 @@
 					"uxid": "f12164a6ea6ce65ff2ca1f2be7251bece8f7c5747ba8ec68e1ec3b27d45d7b9c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "50.000000",
+					"src_txid": "fe01250cfdf84eb0182c033c216891e7e6971cc85976c4c46d9e3c608974d233",
 					"hours": 11848,
 					"calculated_hours": 11903
 				},
@@ -2199,6 +2243,7 @@
 					"uxid": "427462efeb07a6803f013c789ea43d93240f74f886bf9afd63dc1936a7574a37",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "50.000000",
+					"src_txid": "819106dc50373e5293a7e79f179693e85536e8206d82272930ec08410d92402a",
 					"hours": 7510,
 					"calculated_hours": 7564
 				},
@@ -2206,6 +2251,7 @@
 					"uxid": "f9bffdcbe252acb1c3a8a1e8c99829342ba1963860d5692eebaeb9bcfbcaf274",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "27000.000000",
+					"src_txid": "e8fe5290afba3933389fd5860dca2cbcc81821028be9c65d0bb7cf4e8d2c4c18",
 					"hours": 102905,
 					"calculated_hours": 132080
 				}
@@ -2249,6 +2295,7 @@
 					"uxid": "dfd2834342f3a7caf183472c17801aafacd1775378eb843509d17ad858456cb0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "885000.000000",
+					"src_txid": "8de17dff34a8798f2ac89584f5c559e3bb82c280a3f6890386b4dbc5fef0e8cf",
 					"hours": 139293,
 					"calculated_hours": 139293
 				}
@@ -2292,6 +2339,7 @@
 					"uxid": "8ac39d41ec014ca6625e5f17e1fbe62db7a4ac154e0e42a017efa037935ae968",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "884900.000000",
+					"src_txid": "6546dfbe6e61e81f3e9f6c9afdfee1c07758f2e486d731ae4d19b40602367656",
 					"hours": 17411,
 					"calculated_hours": 56739
 				}
@@ -2335,6 +2383,7 @@
 					"uxid": "f9bf35f993452b3d490668bb579fd272da969a1bcca8de0c25000ee57b5d7f54",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "22700.000000",
+					"src_txid": "552a4b194478325ee9f3e4a8648d94bc8eb26432be6fecc881bf71ff9ca15356",
 					"hours": 17848,
 					"calculated_hours": 17848
 				}
@@ -2379,6 +2428,7 @@
 					"uxid": "bae0e928b795e2a80c88161afcbc102dcad6644386f6f44050dde8d586750140",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "881900.000000",
+					"src_txid": "a4c15ae4743246709ec335d33c289576c8893e71f5c3dcee1db6e43eec9242ee",
 					"hours": 7092,
 					"calculated_hours": 11108253
 				},
@@ -2386,6 +2436,7 @@
 					"uxid": "94889dbe1c20eb942b7932c5301737537ac33abd9c81d72e1642ddc70ce320e0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10000.000000",
+					"src_txid": "6ce27da2ddbc15f03330960b4201dbb3a066ad2e9bbd5366a9564f6befdcae2e",
 					"hours": 2231,
 					"calculated_hours": 2231
 				}
@@ -2429,6 +2480,7 @@
 					"uxid": "1d4595b9fa1c6c3d64f48b6ae5f8f861b1c08a022cbcb04b279df448da3db660",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873900.000000",
+					"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 					"hours": 1388810,
 					"calculated_hours": 1388810
 				}
@@ -2472,6 +2524,7 @@
 					"uxid": "412eff3eef889c682da8db3608fce37d1c5ee2cc297bc88d901648e6ccd418f9",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873800.000000",
+					"src_txid": "1f27afc41896d2c7fdbd2620e606440ad12557e9a4bdd6808dcc2c23d4e32978",
 					"hours": 173601,
 					"calculated_hours": 173601
 				}
@@ -2515,6 +2568,7 @@
 					"uxid": "6ad7993fb2728c2c53ac2c8395a6c62d03c5ef9298ca467e7998fb64fd0c90b4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873700.000000",
+					"src_txid": "e8765b4e6fbca87144df59a6f66815b175e81999509504b117636edc34cbe2af",
 					"hours": 21700,
 					"calculated_hours": 21700
 				}
@@ -2558,6 +2612,7 @@
 					"uxid": "0976005ab4540e8211cd929f19634bfaa2f5d8e24177ddb5b803b447ea91f8c3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873600.000000",
+					"src_txid": "bb700553c3e1a32346912ab311fa38793d929f311daeee0b167fa81c1369717e",
 					"hours": 2712,
 					"calculated_hours": 167725
 				}
@@ -2601,6 +2656,7 @@
 					"uxid": "6beca9fb58a327580c614d7fb5622916849756790b661bcabc880666364fdf47",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "863600.000000",
+					"src_txid": "345488861ad3f0d93024c367990e64ef0f7a95bd8b8589f554172f9439808263",
 					"hours": 20965,
 					"calculated_hours": 3029171
 				}
@@ -2644,6 +2700,7 @@
 					"uxid": "f8a1990492f970227ec29e6e095fa724d66fa2d6883bd8723773098d08ca8b3c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "801600.000000",
+					"src_txid": "da82deafc15c36e7dc9cd95663e0dc910ae626ee543147ac7bd8682be00f7baf",
 					"hours": 378646,
 					"calculated_hours": 378646
 				}
@@ -2687,6 +2744,7 @@
 					"uxid": "998487775c0e58420673b70204b83c1d6bb5b70e34b1aa0f8169c85ecec2438e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "765600.000000",
+					"src_txid": "211f5fc97ba1797d78f84d4e4db78415b5ff4121f78369535fe3f8015571c6df",
 					"hours": 47330,
 					"calculated_hours": 47330
 				}
@@ -2730,6 +2788,7 @@
 					"uxid": "6fb116c110fe391448a1dcb985b67439c2e9a71d8bb2fd1cf345ac73ada6166a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "755600.000000",
+					"src_txid": "9003d3caba9587d46d000cc614bb52bed34adcc5ea404c560c986eb6dd756e6b",
 					"hours": 5916,
 					"calculated_hours": 5916
 				}
@@ -2773,6 +2832,7 @@
 					"uxid": "04471fb0797bb931e883f7b95cfff6ee4fea5e19a352ca5425fcd353c4f6aba4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "750600.000000",
+					"src_txid": "e9a6dd585b564b19c55d9f56188a45bfad32fa75703fa6336830035f6fa92e3d",
 					"hours": 739,
 					"calculated_hours": 739
 				}
@@ -2817,6 +2877,7 @@
 					"uxid": "c5df36ce47f6f183475317ab1c53eaa65428c142cb3e3906bf162d80519a203f",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "12700.000000",
+					"src_txid": "6ce27da2ddbc15f03330960b4201dbb3a066ad2e9bbd5366a9564f6befdcae2e",
 					"hours": 2231,
 					"calculated_hours": 1175478
 				},
@@ -2824,6 +2885,7 @@
 					"uxid": "53b376413d550663ab51b229df8b0f55e4055d6577c2d8b5cec8ff748fe0e958",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "18000.000000",
+					"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 					"hours": 1388810,
 					"calculated_hours": 3051530
 				}
@@ -2868,6 +2930,7 @@
 					"uxid": "6b616ad99a946538c3ab101f245bcab211ab39507848425e80cbfc8ec5bdbc67",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "738100.000000",
+					"src_txid": "1ca0a2d44b6439b91eb839e0f99405abdcafe2c1a49c8b49b1739498129bd1a6",
 					"hours": 92,
 					"calculated_hours": 55430171
 				},
@@ -2875,6 +2938,7 @@
 					"uxid": "ef488d5f4a019502115d3b6b50bd364692315c3954d7e93c3ca22e11b92fc528",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "100.000000",
+					"src_txid": "243e1baa955c3f0af42d7acc4c920437dd0a99c754d6c5c2b7defcd143ff288d",
 					"hours": 528376,
 					"calculated_hours": 528376
 				}
@@ -2918,6 +2982,7 @@
 					"uxid": "ecb92dc2f43d4c6ca124575d8456d8894f3cb137875287beaa73180fcae2b3ca",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "737200.000000",
+					"src_txid": "c2c9fe882df3b44fbb125b251a7604a7a4f4195dddff6e5396b7f130744e2b27",
 					"hours": 6994818,
 					"calculated_hours": 101676076
 				}
@@ -2961,6 +3026,7 @@
 					"uxid": "6b4ca83b3f73b62161c90c6da03dff460ca9a5a3ccd6fafca140137416dedc58",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "736000.000000",
+					"src_txid": "6538399868cf772fcfa96e68c51aa6aa66faa95d7c685432e4005880932be134",
 					"hours": 12709509,
 					"calculated_hours": 12709509
 				}
@@ -3004,6 +3070,7 @@
 					"uxid": "2cd58783beb8a9f6278f7a097151531091b5f15afd7735e1facf02aa720c1191",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "735000.000000",
+					"src_txid": "3dfdfea4614d05c2f5eddf5773ef0afc745f1afe585141659df8e03e82897606",
 					"hours": 1588688,
 					"calculated_hours": 1588688
 				}
@@ -3047,6 +3114,7 @@
 					"uxid": "52288a441c70260f6a3eab0e271969d54492377615a6fba8ec3ad26f11dc9768",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "734500.000000",
+					"src_txid": "d30cec3ad3a66562d2513a3656b366ea7da583e6ba45214ac12b9c2219b4c5ea",
 					"hours": 198586,
 					"calculated_hours": 198586
 				}
@@ -3090,6 +3158,7 @@
 					"uxid": "e29ec214f4afd79e6465d03e4d88e552dc69654750a725d74873ee366c58e552",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "734400.000000",
+					"src_txid": "44d05abc2637d9cd2047984023eb5cfa0a146e58821117de30f9c81703189cde",
 					"hours": 24823,
 					"calculated_hours": 24823
 				}
@@ -3133,6 +3202,7 @@
 					"uxid": "8ea58a3736b35f0e3781e94198e8b73bba2536704b84b15900fb32701db8893e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "733400.000000",
+					"src_txid": "072f0738f834db0030d777e6ec0e0443627c51cecffcc55e41d43b0b8edd40d1",
 					"hours": 3102,
 					"calculated_hours": 3102
 				}
@@ -3176,6 +3246,7 @@
 					"uxid": "a1ed39cded6d9a0605b52f25cbedb363e57a168d1ad1d1db437816a401c061ab",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "732400.000000",
+					"src_txid": "b9a795552bec1a722718b44a08ad152656242b1d23afb53d2247b3016d920b7e",
 					"hours": 387,
 					"calculated_hours": 387
 				}
@@ -3219,6 +3290,7 @@
 					"uxid": "f89c968840831d03abaf3c41cf8a405e4b4ddbfb19f5ba300a8ea8e4dcb1d9a4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "731400.000000",
+					"src_txid": "fc02772662176c282c2b6538732d3d6eb1399f006a0b52e64d07fc104038f638",
 					"hours": 48,
 					"calculated_hours": 48
 				}
@@ -3262,6 +3334,7 @@
 					"uxid": "36972dc046829caa340eaecbfeb42f4174bcdecfb87296d56503e5fb10e9de8d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "730200.000000",
+					"src_txid": "9880bebc51471e0b3c520920db836d674f652503314cd74069a59ccad0d0967a",
 					"hours": 6,
 					"calculated_hours": 6
 				}
@@ -3305,6 +3378,7 @@
 					"uxid": "6962c7c1fcc98f532a9003990163bb251811a4700257968a641b1fe975cfc51d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "729200.000000",
+					"src_txid": "578075959959db70ae86f4f60d2ae3ff245727d086eef86ed80db5e1c7c9fbaf",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3348,6 +3422,7 @@
 					"uxid": "d53fae3b48bde2d1328964a2e7f42e8e833983db159ba30f627926dea0db7df0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "728200.000000",
+					"src_txid": "de45a24c9c32f808a3d928f30ba8e1b6ef8117a7c0b7a5d616734d9b121d0c30",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3391,6 +3466,7 @@
 					"uxid": "228794e6b3eb69aecc5334e140afbad22883326dcf229bd3092f238ed9ec800f",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "725700.000000",
+					"src_txid": "16f8b9369f76ef6a0c1ecf82e1c18d5bc8ae5ef8b01b6530096cb1ff70bbd3fd",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3434,6 +3510,7 @@
 					"uxid": "6efc30b4c943ba4de8d2c89901a0b2a4d9a0ecf34713917eae37c6debca616ed",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "724700.000000",
+					"src_txid": "030177271beee04f1a0974d0c5042f07c7ca1db1c5d496fbee3c441b1b7c5bee",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3477,6 +3554,7 @@
 					"uxid": "6c8b1ba9dc7e8900b42d55e9fbe6ea0e00d7eaccf67a7b66c0a2b771cf88ea05",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "724200.000000",
+					"src_txid": "57150aecde96bde972183b9b0d7d27dda2c0179fb71630e92c27856d211335cd",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3520,6 +3598,7 @@
 					"uxid": "59d44fefbe86ebae4118dee90609d6a1c08c36f259c65e3fad63b9e41c37bf0c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "723200.000000",
+					"src_txid": "3bb9fc516dc2c522e28f99e6833253863c550547ce0e0a2dd963a0118b7a44a7",
 					"hours": 0,
 					"calculated_hours": 9192675
 				}
@@ -3563,6 +3642,7 @@
 					"uxid": "5baf8c8ab1a01d80a6f496144815cf6bda5289b34055010e21324ea3950d3299",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "722200.000000",
+					"src_txid": "5701965d326520f86335da87c6d1781fd49f1e66520b94e1783711eba724f482",
 					"hours": 1149084,
 					"calculated_hours": 1149084
 				}
@@ -3606,6 +3686,7 @@
 					"uxid": "dd07d759d92e3d628a35c467dcd919dcae825a9fa79a14855714270dae08c0ce",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "721200.000000",
+					"src_txid": "3fae944ef07d9bcba1bcbc8bde87da50a1232132074803f8442deb563ed2da51",
 					"hours": 143635,
 					"calculated_hours": 143635
 				}
@@ -3649,6 +3730,7 @@
 					"uxid": "c739b518f3f700e810f81523d81b15f968fbf202f389ceaa9d9f303319a00275",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "720200.000000",
+					"src_txid": "79681167a7681edecb998e4a6dccdd0b7be45f163c8f6db23436517936269fb8",
 					"hours": 17954,
 					"calculated_hours": 17954
 				}
@@ -3692,6 +3774,7 @@
 					"uxid": "95694746f813d018be7988aec666b52924a7815adabe9cbdac3f6ab0f51bd1ab",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "719200.000000",
+					"src_txid": "b69536fbec9911da41e9d0c5ca73459f5e692ba155f8b72c0972792e9937a0fe",
 					"hours": 2244,
 					"calculated_hours": 2244
 				}
@@ -3735,6 +3818,7 @@
 					"uxid": "be958e5c47415291a781648335db24e448e1f4f09aa5e9c3f055fbc906b574d7",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "719100.000000",
+					"src_txid": "3e228564e3c187e22bd489857fdb1db7036021e19f688aad56cfee57d5e13ac5",
 					"hours": 280,
 					"calculated_hours": 280
 				}
@@ -3778,6 +3862,7 @@
 					"uxid": "68165429853e18e4414ec6c15630262ebcaa802ff1d83b6cbe116db51cb32066",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "718100.000000",
+					"src_txid": "18607765c3fbd45eafa15d2d62ab3cbc7ba7bd80c42931aae4db75aa02898671",
 					"hours": 35,
 					"calculated_hours": 35
 				}
@@ -3821,6 +3906,7 @@
 					"uxid": "46aeb9ea01bb04e28c55ef11f8e75434dbeee546f7e06bdef332c604590c48a1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "717100.000000",
+					"src_txid": "dc10e0565a14dfecda066577581f3e2d073de34ed3e911ed94413d38fc0a33d2",
 					"hours": 4,
 					"calculated_hours": 4
 				}
@@ -3864,6 +3950,7 @@
 					"uxid": "598503902d2e6cb62d6f6478f09d8da05af6fd2da92b50825da3b7f74b2df34c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "716100.000000",
+					"src_txid": "b0d7ff47658b3e32d8457eb62f6df0c7caaf7feadcbf8cc0c713976026f0404c",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3907,6 +3994,7 @@
 					"uxid": "4b917e7bd3409c43f9f670f2846ce74f9288708df5aa1d9ae142f2411ce426da",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "715100.000000",
+					"src_txid": "be0957035ed2ac444f67273fc5c1c6a39ee373f6f83d1604d0023742a8cd7e42",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3950,6 +4038,7 @@
 					"uxid": "d50a372f8f8cd1e0b10d847613b68ee760f195f5f212d6c59e86312c84dd07ac",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "714800.000000",
+					"src_txid": "c9582c8134fa64fdf08cd93d42035adcced3f16aa8ee1a1393e3fcd7c07aa40c",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -3993,6 +4082,7 @@
 					"uxid": "896865f9b610f9fb69a741596b3ecb9fff3790d40476a9f7852831bdf477aaee",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "713800.000000",
+					"src_txid": "29a883ef9dc67bc683014187b9865c827b5e2f8afd7bf6f3787483318063789e",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4036,6 +4126,7 @@
 					"uxid": "272d5bbd86a87796a20e3e4debc46a2076718800343bee4f72fc0217a98a10a3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "695800.000000",
+					"src_txid": "c3fd04cd27ea311b1a67d40cd3dbb2ea8ae2c6f6139620cb86be29f33ed99171",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4079,6 +4170,7 @@
 					"uxid": "60906201d3e7c67ddb976972460b2b8ed093e1f6720a784cbaea376ca13e6cef",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "670800.000000",
+					"src_txid": "3d9f1aa1b6206275081cb9c26155f6261be1ef9c94b4eaadb1a7e8277a2099fa",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4122,6 +4214,7 @@
 					"uxid": "4912e9dbbb5a4cc7472c27b0212ab443e7b5499207b10666a66257005e182714",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "664464.000000",
+					"src_txid": "d720ca0efb19b964f481724e5d3f932841e9e75a69b998baf4b575cf3298cb87",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4165,6 +4258,7 @@
 					"uxid": "659bac1636b64087ad5d3cb0ae78c52f28ad920016ec67e08415a537e0343072",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "663464.000000",
+					"src_txid": "0e8e352b1f2cd419bca619918ce6d5ec1eac0ba7252d76eef5d9d8f8186f737a",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4208,6 +4302,7 @@
 					"uxid": "97f64c3c636e5fc997e277cd48644055ef51045ed9c473c05dd6e699872a6c3d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "662464.000000",
+					"src_txid": "d5091ca65ff61998dfb4535a7927fb736abf2a81140a11322dcf8226de27cf92",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4251,6 +4346,7 @@
 					"uxid": "122b7a9a61ee04e071002d74ffb26b12ed7952ff9a138b5437f990f4678cc2e5",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "662314.000000",
+					"src_txid": "30e66ff45cfb145eb465e2ebdef0bb10005138bc1727c83888785b04d548e85b",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4294,6 +4390,7 @@
 					"uxid": "c07593d4329f82da243e4bbd7430e4b10e7b35f9ce0a3718d0e6d25d20b4939b",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "661314.000000",
+					"src_txid": "ec79854fade530d84099d5619864a8e1e8ec9d27a086917a239500cada43c6e8",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4337,6 +4434,7 @@
 					"uxid": "4d52106e41dba0099549fd81fb8feb6915225b0125c53faa0f7c578ea78f213a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "660314.000000",
+					"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -4380,6 +4478,7 @@
 					"uxid": "fef9dd3b633274743099e607d9229717a001d6de6a4031479cc30d31d65e8396",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "659314.000000",
+					"src_txid": "3991a257eee265481e713917a3a9c15756f61175bcfc7acfdbe84158e43fd5e6",
 					"hours": 0,
 					"calculated_hours": 269219
 				}
@@ -4423,6 +4522,7 @@
 					"uxid": "21f0fb666dca05d7a43ab26a378f7f7eaedfacde22fa047ca72857e9509cc748",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "659214.000000",
+					"src_txid": "b29222c08f10b8bc4ea18981519a3b0e02b9c9cec63ee28d9ffa2efcaf2a8e5a",
 					"hours": 33652,
 					"calculated_hours": 33652
 				}
@@ -4466,6 +4566,7 @@
 					"uxid": "6b3a0cab1d9ad6fd011a3bac5e6ff4e3f7903bce911dc7fe83926eae557c34c3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "658214.000000",
+					"src_txid": "50fc81b0ba25669105a169a969459ccdb10278051b604a3f91467c2528c83652",
 					"hours": 4206,
 					"calculated_hours": 8113036
 				}
@@ -4509,6 +4610,7 @@
 					"uxid": "372703f8109295f0f58fbee58795979e10dd887869f4fc1da4881ce8a3c0aeb4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "647750.000000",
+					"src_txid": "fb495093f2f4e5c6555c50150ea60c0a6f430e53aa971ebb3e2b5412866a1f06",
 					"hours": 1014129,
 					"calculated_hours": 1019526
 				}
@@ -4552,6 +4654,7 @@
 					"uxid": "14027340f6e1d98bba3f7f5f3b50e3588f8a19e4d021db944e7a28b2643640e1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "635750.000000",
+					"src_txid": "a7665cec98224150968ec1ef9ef2d6b3175c9de8f9f8c7bc786b30cc74997c57",
 					"hours": 127440,
 					"calculated_hours": 146865
 				}
@@ -4595,6 +4698,7 @@
 					"uxid": "8e55f10a0615a0737e6906132e09ac08a206971ba4b656f004acc7f4b7889bc8",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "625750.000000",
+					"src_txid": "9364ed6cfcc289df74dc6bac1993f7ab3441b898cb3f06918198d2476c83dbac",
 					"hours": 18358,
 					"calculated_hours": 44173190
 				}
@@ -4638,6 +4742,7 @@
 					"uxid": "fe6762d753d626115c8dd3a053b5fb75d6d419a8d0fb1478c5fffc1fe41c5f20",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "615700.000000",
+					"src_txid": "f58f664eea258100126636a4111838e489ef5aec848ca8498319c290fa2a0805",
 					"hours": 5521648,
 					"calculated_hours": 45730107
 				}

--- a/src/api/integration/testdata/all-unconfirmed-txns-verbose.golden
+++ b/src/api/integration/testdata/all-unconfirmed-txns-verbose.golden
@@ -22,6 +22,7 @@
 					"uxid": "fe6762d753d626115c8dd3a053b5fb75d6d419a8d0fb1478c5fffc1fe41c5f20",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "615700.000000",
+					"src_txid": "f58f664eea258100126636a4111838e489ef5aec848ca8498319c290fa2a0805",
 					"hours": 5521648,
 					"calculated_hours": 45730107
 				}

--- a/src/api/integration/testdata/block-hash-verbose.golden
+++ b/src/api/integration/testdata/block-hash-verbose.golden
@@ -25,6 +25,7 @@
 						"uxid": "ec2c2238793d71240502de3e7c46ec1d5bf938c76541185f1c3fdf0d99a90795",
 						"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 						"coins": "5.000000",
+						"src_txid": "98db7eb30e13853d3dd93d5d8b4061596d5d288b6f8b92c4d43c46c6599f67fb",
 						"hours": 0,
 						"calculated_hours": 0
 					}

--- a/src/api/integration/testdata/block-last-verbose.golden
+++ b/src/api/integration/testdata/block-last-verbose.golden
@@ -27,6 +27,7 @@
 								"uxid": "c39acd3494113650c1a6a7809287af7b12a78bbd97126d4585dd1715e2cb5a66",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "23100.000000",
+								"src_txid": "ad44a8027a825e82a20cdd910d9bd41d74025601b7668c80655e9b45afb8bb93",
 								"hours": 18586,
 								"calculated_hours": 3020347
 							}

--- a/src/api/integration/testdata/block-seq-verbose-1.golden
+++ b/src/api/integration/testdata/block-seq-verbose-1.golden
@@ -25,6 +25,7 @@
 						"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 						"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 						"coins": "100000000.000000",
+						"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 						"hours": 100000000000000,
 						"calculated_hours": 100000000000000
 					}

--- a/src/api/integration/testdata/block-seq-verbose-100.golden
+++ b/src/api/integration/testdata/block-seq-verbose-100.golden
@@ -25,6 +25,7 @@
 						"uxid": "aee4af7e06c24bccc2f87b16d0708bfea68ac1b420f97914965f4a23ad9e11d6",
 						"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 						"coins": "23000.000000",
+						"src_txid": "c93f8bb30e75ffbc0075a4baf57a0f536e4a9123395b13ce67af5cd2dd0f8cd4",
 						"hours": 294,
 						"calculated_hours": 701385
 					}

--- a/src/api/integration/testdata/blocks-3-5-7-verbose.golden
+++ b/src/api/integration/testdata/blocks-3-5-7-verbose.golden
@@ -27,6 +27,7 @@
 								"uxid": "af0b2c1cc882a56b6c0c06e99e7d2731413b988329a2c47a5c2aa8be589b707a",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "10.000000",
+								"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -72,6 +73,7 @@
 								"uxid": "9eb7954461ba0256c9054fe38c00c66e60428dccf900a62e74b9fe39310aea13",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "10.000000",
+								"src_txid": "a6a709e9388a4d67a47d262b11da5f804eddd9d67acc4a3e450f7a567bdc1619",
 								"hours": 0,
 								"calculated_hours": 2405
 							},
@@ -79,6 +81,7 @@
 								"uxid": "706f82c481906108880d79372ab5c126d32ecc98cf3f7c74cf33f5fda49dcf70",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999980.000000",
+								"src_txid": "c24b92898381fbebe59a457924184f4cce1e7166e140ca75aea5baf854c1ab75",
 								"hours": 3704,
 								"calculated_hours": 3704
 							}
@@ -129,6 +132,7 @@
 								"uxid": "8ff8a647e4542fab01e078ac467b2c9f2e5f7de55d77ec2711f8abc718e2c91b",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "95.000000",
+								"src_txid": "03b3ab821cdaf0ab8cc1a9e2dd30108772ec3bda09e9d3a8c48df9f30d213b38",
 								"hours": 0,
 								"calculated_hours": 0
 							}

--- a/src/api/integration/testdata/blocks-verbose-all.golden
+++ b/src/api/integration/testdata/blocks-verbose-all.golden
@@ -61,6 +61,7 @@
 								"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "100000000.000000",
+								"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 								"hours": 100000000000000,
 								"calculated_hours": 100000000000000
 							}
@@ -699,6 +700,7 @@
 								"uxid": "e3e72ee077c8b0c3f87da7cf50cad8876bd3f489f373d9fe82fc2e971df56f76",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "1000000.000000",
+								"src_txid": "86564b421cd3d4fe6f5f2d7a3e5db9d6fc340892bddd3a150533dff7036d0efe",
 								"hours": 1,
 								"calculated_hours": 1
 							}
@@ -749,6 +751,7 @@
 								"uxid": "af0b2c1cc882a56b6c0c06e99e7d2731413b988329a2c47a5c2aa8be589b707a",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "10.000000",
+								"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -793,6 +796,7 @@
 								"uxid": "0cd548e03bd13bca8647cd13f6baef0c65fd03081aeb6dc3695536e5bc6018ae",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999990.000000",
+								"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 								"hours": 1,
 								"calculated_hours": 5556
 							}
@@ -844,6 +848,7 @@
 								"uxid": "9eb7954461ba0256c9054fe38c00c66e60428dccf900a62e74b9fe39310aea13",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "10.000000",
+								"src_txid": "a6a709e9388a4d67a47d262b11da5f804eddd9d67acc4a3e450f7a567bdc1619",
 								"hours": 0,
 								"calculated_hours": 2405
 							},
@@ -851,6 +856,7 @@
 								"uxid": "706f82c481906108880d79372ab5c126d32ecc98cf3f7c74cf33f5fda49dcf70",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999980.000000",
+								"src_txid": "c24b92898381fbebe59a457924184f4cce1e7166e140ca75aea5baf854c1ab75",
 								"hours": 3704,
 								"calculated_hours": 3704
 							}
@@ -901,6 +907,7 @@
 								"uxid": "dc63c680f408c4e646037966189383a5d50eda34e666c2a0c75c0c6bf13b71a1",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "100.000000",
+								"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -951,6 +958,7 @@
 								"uxid": "8ff8a647e4542fab01e078ac467b2c9f2e5f7de55d77ec2711f8abc718e2c91b",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "95.000000",
+								"src_txid": "03b3ab821cdaf0ab8cc1a9e2dd30108772ec3bda09e9d3a8c48df9f30d213b38",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1001,6 +1009,7 @@
 								"uxid": "17090c40091d009d6a684043d3be2e9cb1dc60a664a9c2e388af1f3a7345724b",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "90.000000",
+								"src_txid": "f832428481690fa918d6d29946e191f2c8c89b2388a906e0c53dceee6070a24b",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1051,6 +1060,7 @@
 								"uxid": "999cc56deae71486a28e19d1ed8d585c2cf07d5ee27d1c33bea186d23aaca06a",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "85.000000",
+								"src_txid": "7229422f3a0afb5f3a9596ed50146440c17a3d54abda0f3c70cd9dc58de96374",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1101,6 +1111,7 @@
 								"uxid": "2f87d77c2a7d00b547db1af50e0ba04bafc5b05711e4939e9ec2640a21127dc0",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "80.000000",
+								"src_txid": "9d87d7bb9e56a3588bacb478c7556280b28c0a49f6e09db8b54a84c20d865f2f",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1151,6 +1162,7 @@
 								"uxid": "ec2c2238793d71240502de3e7c46ec1d5bf938c76541185f1c3fdf0d99a90795",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "5.000000",
+								"src_txid": "98db7eb30e13853d3dd93d5d8b4061596d5d288b6f8b92c4d43c46c6599f67fb",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1201,6 +1213,7 @@
 								"uxid": "3f8c01eefca28ec6d89d34b899fecb5c97f9348b412c61e7c863310b8a85b953",
 								"owner": "2M2VC93aQv5asdcNKt7pzJdkxeL6xLw9JPp",
 								"coins": "1.000000",
+								"src_txid": "4a87de6869c974099e3f5522404fbc7b23f90a8f8dec958bf725317454036cdc",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1245,6 +1258,7 @@
 								"uxid": "9c7d3674d7a6b28a559a052e6d354ec13d2e0396739973c9f0dce08f8c7d157c",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "4.000000",
+								"src_txid": "4a87de6869c974099e3f5522404fbc7b23f90a8f8dec958bf725317454036cdc",
 								"hours": 0,
 								"calculated_hours": 6
 							}
@@ -1295,6 +1309,7 @@
 								"uxid": "34de4a6d093e880f813b4dc466b51f6814923e157ffbba0e9abbc4bfbd938de8",
 								"owner": "2AsyTLyWNR3FGhaMbLckaJyAZN46mrqFfXA",
 								"coins": "1.000000",
+								"src_txid": "9ea7b912cbfca157ef5fe9c59dd2407302d1b4d95414829d93c45bde6c2d42c8",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1339,6 +1354,7 @@
 								"uxid": "0c5d1b6a61c32f9bcc62d3583ac957b3374f0daf1a14fd08679bff2554449840",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "75.000000",
+								"src_txid": "98db7eb30e13853d3dd93d5d8b4061596d5d288b6f8b92c4d43c46c6599f67fb",
 								"hours": 0,
 								"calculated_hours": 153
 							}
@@ -1389,6 +1405,7 @@
 								"uxid": "4a06f4b59bc5626e6a92704b4e4441096e909b884eab84505699a3136abb69b3",
 								"owner": "PRXLNyB64cqaiG4pCoFZZ8Tuv7LWYPpa7m",
 								"coins": "5.000000",
+								"src_txid": "70dd5840d7260cf584457c76d3226312f4d033c023caf8c0ab3a65f9b831e9e0",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1439,6 +1456,7 @@
 								"uxid": "fa2b598d233fe434f907f858d5de812eacf50c7b3fd152c77cd6e246fe356a9e",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999890.000000",
+								"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 								"hours": 4073,
 								"calculated_hours": 6061184
 							}
@@ -1489,6 +1507,7 @@
 								"uxid": "c603e99ceae4d15c20360714ee07ba6e3a944a97ea9285d164c23252e93958b6",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "10.000000",
+								"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1533,6 +1552,7 @@
 								"uxid": "acd35cec566de86b4ed464b6cf3c3ec561140c070134d1e03094775454da2159",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "70.000000",
+								"src_txid": "70dd5840d7260cf584457c76d3226312f4d033c023caf8c0ab3a65f9b831e9e0",
 								"hours": 102,
 								"calculated_hours": 3402
 							}
@@ -1583,6 +1603,7 @@
 								"uxid": "af7deecc9b45c4696ad50246c8aa06b17aa8280b2574f295697a4210fc45f57d",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "65.000000",
+								"src_txid": "c6eccf17b4b952f19548b1924126c9dc409b45f9e6fcc0954a3494e7399f5fd4",
 								"hours": 2268,
 								"calculated_hours": 2268
 							}
@@ -1633,6 +1654,7 @@
 								"uxid": "ec9bbaf9309772ade9860f145705b9e9ee4a70ed1eeed1983d058ccaafd6c02c",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "60.000000",
+								"src_txid": "22766105d0f93d01fed7bed2dcabedfd89fe846621c912b0af845d8ba5d265f8",
 								"hours": 1512,
 								"calculated_hours": 1512
 							}
@@ -1683,6 +1705,7 @@
 								"uxid": "1f4f952c6304e3991cf33519f1084921d50ecfd845edc48bd3b7b7229e28f2a6",
 								"owner": "Kb9SqqTVA3XyQjZYb4wYrBVUeZWRKEQyzZ",
 								"coins": "5.000000",
+								"src_txid": "67f180076fed1599152c62337a12deee7e1a468b19f7e720df51415c28bfb986",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1733,6 +1756,7 @@
 								"uxid": "4c84a4bf9a1b1a3a53d8bf78e8823ca3135321089968068ac60da32083027846",
 								"owner": "Kb9SqqTVA3XyQjZYb4wYrBVUeZWRKEQyzZ",
 								"coins": "4.000000",
+								"src_txid": "c820bf59805b4889e59ce5fa320dcccfce5180de5f0f8baef7b391049ea8e286",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1784,6 +1808,7 @@
 								"uxid": "182b4c32bb5fe0e6809a19db63eecbeefde97a6c043b9248da94d428ab5a94c2",
 								"owner": "2bvEzLx4mgyQkYL5bkSc2rD9V1nqWBqn8vp",
 								"coins": "1.000000",
+								"src_txid": "c820bf59805b4889e59ce5fa320dcccfce5180de5f0f8baef7b391049ea8e286",
 								"hours": 0,
 								"calculated_hours": 0
 							},
@@ -1791,6 +1816,7 @@
 								"uxid": "20900f1d317e0b10ebab7190a34265f52783ff4f85675398b497ab8eb3723a3c",
 								"owner": "2bvEzLx4mgyQkYL5bkSc2rD9V1nqWBqn8vp",
 								"coins": "1.000000",
+								"src_txid": "eb0a48072c5da37962c07d205a1843311f98e886cfcbdb2813359677f36bebc2",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1835,6 +1861,7 @@
 								"uxid": "f3ce12886e74d6407f9580b47e72156a917083b66ebaa46263c7fde2df35116e",
 								"owner": "Kb9SqqTVA3XyQjZYb4wYrBVUeZWRKEQyzZ",
 								"coins": "3.000000",
+								"src_txid": "eb0a48072c5da37962c07d205a1843311f98e886cfcbdb2813359677f36bebc2",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1886,6 +1913,7 @@
 								"uxid": "4168b9378363cd81939e667cf78055d35a60d3101f5f9e3d2ae709e3981e29fc",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999880.000000",
+								"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 								"hours": 4040790,
 								"calculated_hours": 4543507
 							},
@@ -1893,6 +1921,7 @@
 								"uxid": "d9dae1f82177f979b07016a341ed5c281ed6ed8eaa785a8a107ec16efbe541ef",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "10.000000",
+								"src_txid": "686db0a8cd429970bb91163033703410d4750c86ba485709fe1a3faabbbb42f6",
 								"hours": 0,
 								"calculated_hours": 4
 							}
@@ -1943,6 +1972,7 @@
 								"uxid": "8793a3782bf673393a8f909f267f3bfcc713b600460893b571fd55f675ac65ba",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999880.000000",
+								"src_txid": "56e7bd13dc4c6e1cd80aba66a0a9fed650d0646659ac774e3f1b415848755d85",
 								"hours": 567938,
 								"calculated_hours": 567938
 							}
@@ -1993,6 +2023,7 @@
 								"uxid": "778048daec0c83f89525a6d69b60c407d090bb1666711b1c560e6ebee8dcc452",
 								"owner": "bNQHMc2nM8x2fssmyUp6QWY1ow6LzB7kZz",
 								"coins": "5.000000",
+								"src_txid": "03b3ab821cdaf0ab8cc1a9e2dd30108772ec3bda09e9d3a8c48df9f30d213b38",
 								"hours": 0,
 								"calculated_hours": 284
 							}
@@ -2043,6 +2074,7 @@
 								"uxid": "98b3e6e6d4ed36159b7dbf5f305174fc0c255d2d97528b35a67d50b9968e2b2f",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "10.000000",
+								"src_txid": "c24b92898381fbebe59a457924184f4cce1e7166e140ca75aea5baf854c1ab75",
 								"hours": 0,
 								"calculated_hours": 629
 							}
@@ -2087,6 +2119,7 @@
 								"uxid": "92ae7cf57ad1363a60ce019818f7304040959329b6513f9a2d0f6b464bacafea",
 								"owner": "bNQHMc2nM8x2fssmyUp6QWY1ow6LzB7kZz",
 								"coins": "3.000000",
+								"src_txid": "f2f9926afcd29405327ddb772988a73dc13a67b1fcaa42ad98a416060e96adce",
 								"hours": 35,
 								"calculated_hours": 35
 							}
@@ -2131,6 +2164,7 @@
 								"uxid": "18ea1b3cceb2ca40c01efc8f3cfd7d1d0dd69430ecdf655515aa4f8b21bd2644",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "10.000000",
+								"src_txid": "260d249883165aa9e59e17fb2bd8ba8995d2c3644993530985f8b813ed378650",
 								"hours": 78,
 								"calculated_hours": 78
 							}
@@ -2181,6 +2215,7 @@
 								"uxid": "64194899d317e2a007f89df14538795547e927c242a92f83180e6cc952304964",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "5.000000",
+								"src_txid": "9004c779cff67b3895500ec14b2c2e566127bb11a8af3358fe8a63dcfae9badc",
 								"hours": 9,
 								"calculated_hours": 9
 							}
@@ -2226,6 +2261,7 @@
 								"uxid": "569aa1260e734017c4eee06d84ab4a6285e2ca2041940b2915d9141527caf179",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "5.000000",
+								"src_txid": "9004c779cff67b3895500ec14b2c2e566127bb11a8af3358fe8a63dcfae9badc",
 								"hours": 9,
 								"calculated_hours": 9
 							},
@@ -2233,6 +2269,7 @@
 								"uxid": "eb446b8372559249c8e269b6cd028588e2e9e4f8fe9357719da9d1c22aa29911",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "5.000000",
+								"src_txid": "327375203f20cb68847351c30a48597c0588a8c14319a4eb47bf440207fd045a",
 								"hours": 1,
 								"calculated_hours": 1
 							}
@@ -2277,6 +2314,7 @@
 								"uxid": "e702df2703c3de180f3e4a0e9a503bd534037c2d68e858e97a317575c5a97d95",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "10.000000",
+								"src_txid": "e89ee3e90e72108e4cd6ccb95c9f8d2b18ccfaa7ce61a7d297454debd69cebbf",
 								"hours": 1,
 								"calculated_hours": 1
 							}
@@ -2327,6 +2365,7 @@
 								"uxid": "10998e83dc5dfe3c3f5f28ef3e5e2fced4dbd1da389678b0ea3ddb552851b6bf",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "6.000000",
+								"src_txid": "08bf0f8f4a8547bcab1fef035adac2a66c80369b4485a736bdd676e782bbb037",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -2372,6 +2411,7 @@
 								"uxid": "41c6d29aa5de770de684ab19b40bd75b99ec7f1a5ff7d15288ae4bfff568eabd",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "4.000000",
+								"src_txid": "08bf0f8f4a8547bcab1fef035adac2a66c80369b4485a736bdd676e782bbb037",
 								"hours": 0,
 								"calculated_hours": 0
 							},
@@ -2379,6 +2419,7 @@
 								"uxid": "9e5779445f60d62b471862339d7a83dd8355c7a89d5fc3b751f98e9414628ec2",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "6.000000",
+								"src_txid": "3170f0635cc40aded3a38f84f2ae07bd2238550ea4ee867328d0f891ea9abf14",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -2423,6 +2464,7 @@
 								"uxid": "d46e91fea3c8a6428885f941e5152dbc7f9abd356ad4d054bf20e0e806f1ec99",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "10.000000",
+								"src_txid": "fba515a9eeaedb891c4dca862bd06108e0452270890b362f0b353b4c86845618",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -2467,6 +2509,7 @@
 								"uxid": "ad742bbc7420c08881e6ccf35e34e8472c0dd6386792359aedcfb752ca618c33",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999790.000000",
+								"src_txid": "cff53a059d55f2c90f6dd7ce7de2cc07cbdbd50b25867cba0f41cd0192614d0d",
 								"hours": 70992,
 								"calculated_hours": 3113963
 							}
@@ -2517,6 +2560,7 @@
 								"uxid": "108520145179c00f581d91e273714811fe6e82ee059d65218eea91154ebd8205",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "998790.000000",
+								"src_txid": "a76cd63b71f1f5425941cd567627e1dcdc8c34306a7945ea48755f5a46efb6f5",
 								"hours": 389245,
 								"calculated_hours": 389245
 							}
@@ -2567,6 +2611,7 @@
 								"uxid": "e79c94aa7013c7611901839236b8a1cdf70e8ef7c40b9e33f99359136de981d6",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "988790.000000",
+								"src_txid": "c38b47bd576e3bced2a9309c3df7622064e71177f54020d77193d5cac310719c",
 								"hours": 48655,
 								"calculated_hours": 48655
 							}
@@ -2617,6 +2662,7 @@
 								"uxid": "c65a9e6aa33244958e9595e9eceed678f9f17761753bf77000c5474f7696da53",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "978790.000000",
+								"src_txid": "b56f3e9239da5c5f9bb5ca80226b8454ba36ce6012f8e323a50c9d9c4eb4a834",
 								"hours": 6081,
 								"calculated_hours": 6081
 							}
@@ -2668,6 +2714,7 @@
 								"uxid": "f48432d381a10abecbd1357d81705ea922246e92170fe405d1a4a35c5ceef6a4",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "1000.000000",
+								"src_txid": "a76cd63b71f1f5425941cd567627e1dcdc8c34306a7945ea48755f5a46efb6f5",
 								"hours": 389245,
 								"calculated_hours": 389256
 							},
@@ -2675,6 +2722,7 @@
 								"uxid": "6bbf13da052e1baade111ae8bb85548732532c8f5286eba8345d436d315d1c93",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "9000.000000",
+								"src_txid": "cf4fe76a08e3296b6f6abdb949604409be66574f211d9d14fde39103c4cfe1d6",
 								"hours": 760,
 								"calculated_hours": 760
 							}
@@ -2727,6 +2775,7 @@
 								"uxid": "e3e95cd390c42d2f08e2c173135620e09c7a2ec1cf80ff75fbc3940fa5712b3c",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "55.000000",
+								"src_txid": "67f180076fed1599152c62337a12deee7e1a468b19f7e720df51415c28bfb986",
 								"hours": 1008,
 								"calculated_hours": 2035
 							},
@@ -2734,6 +2783,7 @@
 								"uxid": "7f44d7ef014419278137cbaa344cb550fc3c07355ec619d917bea3bc15fb8817",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "2.000000",
+								"src_txid": "f2f9926afcd29405327ddb772988a73dc13a67b1fcaa42ad98a416060e96adce",
 								"hours": 35,
 								"calculated_hours": 56
 							},
@@ -2741,6 +2791,7 @@
 								"uxid": "61c61dfe5b82fde557a698b402c82ac0205929478e705cbadec7f5d47a51d403",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "3.000000",
+								"src_txid": "044a75b1d3d273cae560ca43f9351d9acde206b0ad5578eb3adc2598886b5134",
 								"hours": 4,
 								"calculated_hours": 35
 							}
@@ -2791,6 +2842,7 @@
 								"uxid": "88162721a552b1422546024772fc822faa187e897754e0a579e5e4a92a7cf4c9",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "55.000000",
+								"src_txid": "d368fc3112b522c52a5b191981ca52678cc7db29bdc3493cf551be88d109ef9c",
 								"hours": 265,
 								"calculated_hours": 265
 							}
@@ -2841,6 +2893,7 @@
 								"uxid": "195f5e50b4eed1ec7ff968feca90356285437adc8ccfcf6623b55a4eebf7bbb5",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "969790.000000",
+								"src_txid": "cf4fe76a08e3296b6f6abdb949604409be66574f211d9d14fde39103c4cfe1d6",
 								"hours": 760,
 								"calculated_hours": 3203760
 							}
@@ -2891,6 +2944,7 @@
 								"uxid": "cb8efc0b1082c39258cb6efd59f64d88b36fcb60143c826829fc5f0ed5c0d668",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "944790.000000",
+								"src_txid": "df622e8c9dfaed1d7dca83ad7f6d8946bb86b81398bad521d858cbefef8e4688",
 								"hours": 400470,
 								"calculated_hours": 400470
 							}
@@ -2941,6 +2995,7 @@
 								"uxid": "a6061defc41a8a55e37eaf56ebaa1177446f61719b1d5126698e79a6023f5367",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "944780.000000",
+								"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 								"hours": 50058,
 								"calculated_hours": 50058
 							}
@@ -2991,6 +3046,7 @@
 								"uxid": "3b5f72e772ea886dd872b9087395398133576a6561072d5294fbcd04b49e1d95",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "944770.000000",
+								"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 								"hours": 6257,
 								"calculated_hours": 6257
 							}
@@ -3041,6 +3097,7 @@
 								"uxid": "f265bea876ffcfb8cf64df3aca4dae4a8d7f424ff495d91fb322feddb3a7e505",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "944760.000000",
+								"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 								"hours": 782,
 								"calculated_hours": 782
 							}
@@ -3091,6 +3148,7 @@
 								"uxid": "19efa2bd8c59623a092612c511fb66333e2049a57d546269c19255852056fead",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "9000.000000",
+								"src_txid": "0e91a08561e85a36ddf44e77b9228f7d561c18c0b46d19083d4af511085b697e",
 								"hours": 48752,
 								"calculated_hours": 95777
 							}
@@ -3141,6 +3199,7 @@
 								"uxid": "f8ad5c72e7822c7ac9a1dce8de583e34f6f830052bc0a02d749e9e81790dae86",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "10000.000000",
+								"src_txid": "b56f3e9239da5c5f9bb5ca80226b8454ba36ce6012f8e323a50c9d9c4eb4a834",
 								"hours": 6081,
 								"calculated_hours": 58747
 							}
@@ -3191,6 +3250,7 @@
 								"uxid": "5fa90c22a26ecec8c03696a018b590a5e1679efa9cb5e8263facf9bcc6628db6",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "8000.000000",
+								"src_txid": "be27621ad46680b343cc1406f5c6a1717704ce169e988ed7afb586f8112ae6f0",
 								"hours": 11972,
 								"calculated_hours": 11994
 							}
@@ -3241,6 +3301,7 @@
 								"uxid": "e6d9b56e075a6adf520d1ae7fbab9ae06353ae0b93dc8cb17d82cc3628009a50",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "944750.000000",
+								"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 								"hours": 97,
 								"calculated_hours": 23715
 							}
@@ -3291,6 +3352,7 @@
 								"uxid": "e4fa8fe06d04bb438323f295eea23535856be08b369be71a2ce3e9e7bc0b1e09",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "7000.000000",
+								"src_txid": "231254039042675300dbdd61a6ca54941214e383b5f6380323f848482b4f4628",
 								"hours": 1499,
 								"calculated_hours": 1537
 							}
@@ -3341,6 +3403,7 @@
 								"uxid": "f37efd851f76854852fdb8b8ba9afa2c5b7859315cc1fd12c12bf6831c59beb2",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "9000.000000",
+								"src_txid": "814694a8e32f1c81b627f8eb704622c8893d197bf32bbd7e1bf73bec9a831d7d",
 								"hours": 7343,
 								"calculated_hours": 7443
 							}
@@ -3391,6 +3454,7 @@
 								"uxid": "df5d6e09da2585a6ac1a37aea2370fa25e9049b549049202d5417138bf033cfa",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "10000.000000",
+								"src_txid": "c38b47bd576e3bced2a9309c3df7622064e71177f54020d77193d5cac310719c",
 								"hours": 48655,
 								"calculated_hours": 101571
 							}
@@ -3441,6 +3505,7 @@
 								"uxid": "2df1e88589be43c55d7c6c3dbcbd663fb759b3245eb8d86b0b9cdaa989556aea",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "943750.000000",
+								"src_txid": "d154d8262abbf517c67d529b0fea7cdf097433bd296d5795b17c6379cb1b1430",
 								"hours": 2964,
 								"calculated_hours": 13450
 							}
@@ -3491,6 +3556,7 @@
 								"uxid": "f5beae016bda8260218fc05468c300fa71ddd46f4c6337fffac8d83229461f5f",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "6000.000000",
+								"src_txid": "88d239f2584c78b73a1905fd0dcce3beabfdfc5a9c54518862b009e22e972c68",
 								"hours": 192,
 								"calculated_hours": 292
 							}
@@ -3541,6 +3607,7 @@
 								"uxid": "298fabb8217a2b0322f104b0cb295383bfdbc599d6a81e07610e0922eb99f89a",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "8000.000000",
+								"src_txid": "374f01de8274656147be0a23ccc5677773da6f32b071ee796bda0851b6dcd2ac",
 								"hours": 930,
 								"calculated_hours": 1063
 							}
@@ -3591,6 +3658,7 @@
 								"uxid": "3d7dd4d41e613fe8153f5e5f62b79494e9db9ed98f875d929ca1f90ecfe2d50b",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "9000.000000",
+								"src_txid": "8fba29db2e3e8cad785e723f95aa5fa46ae0dd8b2bb62586977f20e698642cfb",
 								"hours": 12696,
 								"calculated_hours": 12846
 							}
@@ -3641,6 +3709,7 @@
 								"uxid": "c5150380691c542b9bdf4cf2280ac612e0576c349f99d47d0a03c77eedc48731",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "942750.000000",
+								"src_txid": "61a33b49e97bfe2d5f026bf45fae43a1b9bdf08c60ec8db017da720a69790c7f",
 								"hours": 1681,
 								"calculated_hours": 12156
 							}
@@ -3691,6 +3760,7 @@
 								"uxid": "53ea8733d94ae54bade0b55df03a03b3c0f6e6683b9260c36b14e3fc311d6f49",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "5000.000000",
+								"src_txid": "5d1cb86b48c8834c8c12fc36a83259609300f2f6a148faa1492a473cee21bc02",
 								"hours": 36,
 								"calculated_hours": 105
 							}
@@ -3741,6 +3811,7 @@
 								"uxid": "77769e6a01cf3dca201ade501767d0abf20dea19d694f3272b647a9a651fdee9",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "8000.000000",
+								"src_txid": "77a69f4c8afd858a2f6767bb9980d4af6520e02b076bf2a78b935021e1147c71",
 								"hours": 1605,
 								"calculated_hours": 1693
 							}
@@ -3791,6 +3862,7 @@
 								"uxid": "9bbb8d620aae3efc7c21bb7d6a7159eda441a83e0fef2cd98f8240b38857d648",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "941750.000000",
+								"src_txid": "4aeafd20b9df56ec852a2c257ff1630b9530d8375a4e72f20238ea36835f76d5",
 								"hours": 1519,
 								"calculated_hours": 9366
 							}
@@ -3841,6 +3913,7 @@
 								"uxid": "83b5fa4051dbfd50ba903374e5e583a9345c6a980505ee56963de9bd8e539e36",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "4000.000000",
+								"src_txid": "057ae2bee6e1fc2c9997d48aab3e348a7f17ad0305d6e6a14f4f663404b4a00a",
 								"hours": 13,
 								"calculated_hours": 46
 							}
@@ -3891,6 +3964,7 @@
 								"uxid": "1efc8693845733061e1407a74e86976a52a69c63a14d6a79e1f3e45277662900",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "7000.000000",
+								"src_txid": "4ce860140dbb5f90f39086b0c51323005145a95b365204bd33e3d90fbdc35f51",
 								"hours": 132,
 								"calculated_hours": 345
 							}
@@ -3941,6 +4015,7 @@
 								"uxid": "25ad0d5ae6a1a9bc61c6b9099fb7829111977a59e1183de4227a0a5352555639",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "940750.000000",
+								"src_txid": "29c229c97d27bcaf842a367520e1916fb855921906bddf4a3b0413ad3f11517b",
 								"hours": 1170,
 								"calculated_hours": 11622
 							}
@@ -3991,6 +4066,7 @@
 								"uxid": "acc75d51ff9f18a224d1ca0481917e2a67298de40955711cd97a08f6733b5b6a",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "939750.000000",
+								"src_txid": "42227683dd9c149859d0578ab300d8509d513afadf7834fd8ae7a321cc07d833",
 								"hours": 1452,
 								"calculated_hours": 1452
 							}
@@ -4041,6 +4117,7 @@
 								"uxid": "5c1069a3aa6628ed7f9bdb300bec1a7e7ca6fb4645528a8c6a27c167e7dfe698",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "938750.000000",
+								"src_txid": "d803ab903f68f7861cd8eff93b3c097c5b8f6a697ca67bb01e7e645060839fd0",
 								"hours": 181,
 								"calculated_hours": 181
 							}
@@ -4091,6 +4168,7 @@
 								"uxid": "8190fd31c005510d550c8a241b127fad2558c82aed9483fb4423193d5f4429e3",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "913750.000000",
+								"src_txid": "3bf485890e91268452dc3136c0b294dc9909b3aaa10b9c936743e6e9b1a56f61",
 								"hours": 22,
 								"calculated_hours": 22
 							}
@@ -4141,6 +4219,7 @@
 								"uxid": "450cd7795bb3625daa99d6b64b9a8786d593bf1cad986d6c2933dae04b74a593",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "888750.000000",
+								"src_txid": "f51e2ce31961b0186e04cc9d78857c3c21d3e2afb25c050d8c1d67d3320fcc07",
 								"hours": 2,
 								"calculated_hours": 2
 							}
@@ -4193,6 +4272,7 @@
 								"uxid": "3fe6b13824f28d69588c309278420069bc0efae95367d0d6f93cb40af15eeaa6",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "6000.000000",
+								"src_txid": "bbd1d4b6fe89a5986efbea9f7996cca2a515c3f0788cedccc21990dc78d83509",
 								"hours": 43,
 								"calculated_hours": 443
 							},
@@ -4200,6 +4280,7 @@
 								"uxid": "5a7b2b6568cfa4ff5d44e98446aed92438ede0103b9994cfa3389bd02a35239b",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "25000.000000",
+								"src_txid": "3bf485890e91268452dc3136c0b294dc9909b3aaa10b9c936743e6e9b1a56f61",
 								"hours": 22,
 								"calculated_hours": 230
 							},
@@ -4207,6 +4288,7 @@
 								"uxid": "9639a86df8da288fb0fc6a92fa086f3cd5a8387705a14ddd2aa5e30c6c3fc3fb",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "25000.000000",
+								"src_txid": "f51e2ce31961b0186e04cc9d78857c3c21d3e2afb25c050d8c1d67d3320fcc07",
 								"hours": 2,
 								"calculated_hours": 71
 							}
@@ -4257,6 +4339,7 @@
 								"uxid": "c7919b892eeb751456d456b37ccde7350a3fca0dda03b17ec426a56f12dcf192",
 								"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 								"coins": "1000.000000",
+								"src_txid": "d154d8262abbf517c67d529b0fea7cdf097433bd296d5795b17c6379cb1b1430",
 								"hours": 2964,
 								"calculated_hours": 3100
 							}
@@ -4308,6 +4391,7 @@
 								"uxid": "9953e00abe05db134510693a44b8928ca9b29d0009b38d9c4f8dcdedee7edc35",
 								"owner": "4EHiTjCsxQmt4wRy5yJxBMcxsM5yGqtuqu",
 								"coins": "1000.000000",
+								"src_txid": "0e91a08561e85a36ddf44e77b9228f7d561c18c0b46d19083d4af511085b697e",
 								"hours": 48752,
 								"calculated_hours": 57799
 							},
@@ -4315,6 +4399,7 @@
 								"uxid": "8f52e126bbc359bc3bfd230d82649c3d1c622e8f9c20dae7ccd73bd0b4ee2bad",
 								"owner": "4EHiTjCsxQmt4wRy5yJxBMcxsM5yGqtuqu",
 								"coins": "5.000000",
+								"src_txid": "a95317361364e8cc08a150840bac8a97ea1f56278f8834ca2a2f16c24c4a7f0f",
 								"hours": 387,
 								"calculated_hours": 387
 							}
@@ -4365,6 +4450,7 @@
 								"uxid": "e2807345a3e76b7050038a9ec40d5a62bd4dcc6b1ed79f186213a32caf7008a1",
 								"owner": "j6pa8kdKqHbxRm2VXJVbzigQDFzqTVfvfq",
 								"coins": "50.000000",
+								"src_txid": "edca397ceedb5fb4462b0aff8fe7f9da5091a4e68f11a34c79daf2c5ae7dd748",
 								"hours": 7273,
 								"calculated_hours": 7273
 							}
@@ -4416,6 +4502,7 @@
 								"uxid": "73ad63090201c13e6fb55d2e51ec5606fe49a40640bea995e347e7389fcea6c6",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "50.000000",
+								"src_txid": "ced30c4ac3107997efa90faa40c8baed47dafc8ddb4feae3ba21275401c36280",
 								"hours": 33,
 								"calculated_hours": 393
 							},
@@ -4423,6 +4510,7 @@
 								"uxid": "4aca4c715985da352bd9aa84787868dac4f4e305c420fe79e6f05acee3bba14a",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "25000.000000",
+								"src_txid": "df622e8c9dfaed1d7dca83ad7f6d8946bb86b81398bad521d858cbefef8e4688",
 								"hours": 400470,
 								"calculated_hours": 575956
 							}
@@ -4473,6 +4561,7 @@
 								"uxid": "b44ee00208690c2123989f40edaff0224825afb20ca0952fbd90bddfd3213642",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "863750.000000",
+								"src_txid": "abed13c2a552633d26b5b51c3ac5abf9808756c0203869ed185a7cd673702ba2",
 								"hours": 0,
 								"calculated_hours": 7814538
 							}
@@ -4524,6 +4613,7 @@
 								"uxid": "70dfcdd1a8a321ffd22c4ce313763464f78c2f85a97bb369ac8b82f76d2ea961",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "3000.000000",
+								"src_txid": "e3b7236ad4b209d664ee1e2549f2a0d34a3ba58b12ee46f98fba73c01574e484",
 								"hours": 5,
 								"calculated_hours": 58468
 							},
@@ -4531,6 +4621,7 @@
 								"uxid": "a96ca17d6af858af8c6f24f607a742ae2979ab8f660b8363b7fbe18625c8a048",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "25000.000000",
+								"src_txid": "3872797c8f9964e6ad19552b9b88d2af07be32866bdb9b9c60aa7086f253af43",
 								"hours": 93,
 								"calculated_hours": 485343
 							}
@@ -4582,6 +4673,7 @@
 								"uxid": "f5867b05823c81fc53de36b140415b3b98e4f4cec5883512f8553f70c550d8e7",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "7000.000000",
+								"src_txid": "8d10b0ba11d9dd63d3a3522bc35bd260e8da9109298aa488355ea7201eb961b7",
 								"hours": 211,
 								"calculated_hours": 136742
 							},
@@ -4589,6 +4681,7 @@
 								"uxid": "22edb5931e1c54382f18e41ef774931efb08c278209a1fe8a34100147b707220",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "25000.000000",
+								"src_txid": "abed13c2a552633d26b5b51c3ac5abf9808756c0203869ed185a7cd673702ba2",
 								"hours": 0,
 								"calculated_hours": 485597
 							}
@@ -4639,6 +4732,7 @@
 								"uxid": "dbe677fec72761ed99467a4d45871aafe173d7dc133e8db0346e3f262ae2598a",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "27000.000000",
+								"src_txid": "c1fb9372439d7f43d17809afc2d1bc9b2aa81fa9fccc1d837c79e649ec4843db",
 								"hours": 67976,
 								"calculated_hours": 68351
 							}
@@ -4689,6 +4783,7 @@
 								"uxid": "6060c983054614b8801e405de697c443a1edebd3236582f89f01c6cf6a165c3f",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "862750.000000",
+								"src_txid": "29798149e90f6442489bcc3294f455441a5a401e81491ed06bdc2c850756f0d9",
 								"hours": 976817,
 								"calculated_hours": 1005575
 							}
@@ -4739,6 +4834,7 @@
 								"uxid": "3a7e60306a5fc882d0c4edcb2990d14be6b80dad1a41b06f8ae5e0308078bafa",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "31000.000000",
+								"src_txid": "3872797c8f9964e6ad19552b9b88d2af07be32866bdb9b9c60aa7086f253af43",
 								"hours": 93,
 								"calculated_hours": 744403
 							}
@@ -4789,6 +4885,7 @@
 								"uxid": "09661724179523e8aec95862a5fd12dd1aa50f39f193f81eece0d7aea6197103",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "31000.000000",
+								"src_txid": "2558a7cd524acdb58f822a56bd51e8905182b2b35fbfdb1246ce6dc9930d14eb",
 								"hours": 77792,
 								"calculated_hours": 219961
 							}
@@ -4839,6 +4936,7 @@
 								"uxid": "6a8bc7ef9e8e7b67fd270cf37022edadb13f1fc2ba4e7a026f7ce2ab30cc4572",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "30000.000000",
+								"src_txid": "d80d49958166fd7b35cee63cfc4a4fdd434484f9bfd9444f62a1b856da36e9c7",
 								"hours": 27495,
 								"calculated_hours": 27495
 							}
@@ -4889,6 +4987,7 @@
 								"uxid": "129726406b3101d51ffd5bfca59a501184d6c8ca363be4ef1b8d8bf48a6c70e0",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "861750.000000",
+								"src_txid": "0cded82aa3ac92d78e23d2d0d7faf93c675fc9a321ad55105f65b6fca444b1e7",
 								"hours": 125696,
 								"calculated_hours": 161602
 							}
@@ -4939,6 +5038,7 @@
 								"uxid": "05f42f22f5fea4b5cac8182dc2b4f280149c686434c6d4195a119a8d02ab24b2",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "861050.000000",
+								"src_txid": "b7b42b1b29acab0a2328aaf368ec74be49b4d4caf827e82b439ef4d8be976a55",
 								"hours": 20200,
 								"calculated_hours": 20200
 							}
@@ -4989,6 +5089,7 @@
 								"uxid": "fa761f3b902ced1ad8e94231af3447315a8c8bcdbbdcfcd69bb74ca5ae66f6e9",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "26000.000000",
+								"src_txid": "5db4378f5abcbb48774fc3731a164fb7bbdccf410c3ff829c5706e4d9ef1b1c6",
 								"hours": 8543,
 								"calculated_hours": 129298
 							}
@@ -5039,6 +5140,7 @@
 								"uxid": "dc8162cf85ce1a434adebab2d13abffb587c0e50b86fd1a997bca67f07a66ebd",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "30000.000000",
+								"src_txid": "0ad2691de38a15ec31b0fbe9a0c1175138c9d7b7558db2f016a23619f3dbbc6d",
 								"hours": 93050,
 								"calculated_hours": 95300
 							}
@@ -5089,6 +5191,7 @@
 								"uxid": "15700b88043b3c08a46c3c4e36e7f431291a26aef1ef26c44ee413feee14b950",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "29700.000000",
+								"src_txid": "8374d85130bbcf496bff138cd040f91fa362eb1b6b6a1c7c9285523437d5589c",
 								"hours": 3436,
 								"calculated_hours": 5086
 							}
@@ -5139,6 +5242,7 @@
 								"uxid": "4e1a98a72639efa6253a7cbea0f3b499fa24fb88612ad81414d20e46d2b5784e",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "860050.000000",
+								"src_txid": "ca51f9d0a19bf326d6dd39a1e4dd240adaaae279411093d4a5b20f54cddabb95",
 								"hours": 2525,
 								"calculated_hours": 21637
 							}
@@ -5189,6 +5293,7 @@
 								"uxid": "a68c6c646b6bd42f509a82d0218c8ee648b4a40da20eb0599449a7249b10fee9",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "25000.000000",
+								"src_txid": "cf5a1fad27f8f874f67d3162ae6347154c980ebd97c668d610280418f0f53ce7",
 								"hours": 16162,
 								"calculated_hours": 16717
 							}
@@ -5239,6 +5344,7 @@
 								"uxid": "b187246f68a768f65663b8a208ab107a9bc24af6a062acf3ad41aeb899315a49",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "29000.000000",
+								"src_txid": "efc98a4f94ffda2f1d6575048d75728f228a0bef0467c331f085a0f41f97ae45",
 								"hours": 11912,
 								"calculated_hours": 12234
 							}
@@ -5289,6 +5395,7 @@
 								"uxid": "24c49699aab32caf9456a6b4dacd4d820c853c7639e5500b3be6326660312917",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "28700.000000",
+								"src_txid": "a0956843d442bd4b592d0c1323d153c3c1b2d7d52a86629444de6d1d1b6a4c33",
 								"hours": 635,
 								"calculated_hours": 1033
 							}
@@ -5339,6 +5446,7 @@
 								"uxid": "33e0c4c9536afffd491fef6294f22ffb0d16902493946a051db0b218728a1c44",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "859050.000000",
+								"src_txid": "bd617ec27c2bea642fad8c153178e11ca08456d752249324e3011f27c845f87a",
 								"hours": 2704,
 								"calculated_hours": 14635
 							}
@@ -5389,6 +5497,7 @@
 								"uxid": "d45d0597c7d41fdc69ed09a139925327142589f1e4fb877285fa63c6fa126d38",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "24000.000000",
+								"src_txid": "98baeb9799902593d0f61ee22947089a798c6adafd05dc6a5ea918d982a19857",
 								"hours": 2089,
 								"calculated_hours": 2355
 							}
@@ -5439,6 +5548,7 @@
 								"uxid": "74f7dcc6e516634b5d5722d8664ffabaca3b708a53497bb420ced7c300c39806",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "28000.000000",
+								"src_txid": "54e65c445d0af9dda82085ca4bfe0f326ae54ea2a03bd37e07f81d937de97777",
 								"hours": 1529,
 								"calculated_hours": 1762
 							}
@@ -5489,6 +5599,7 @@
 								"uxid": "fb4d5dcc1c3ac97444e96aa7da392b0d7faf7b7373504c70e497228a4695a7f1",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "27700.000000",
+								"src_txid": "e2d9da9342b21659da0a679536f9d6f533a4ce7dc33a7f768c3441ca3640458d",
 								"hours": 129,
 								"calculated_hours": 436
 							}
@@ -5539,6 +5650,7 @@
 								"uxid": "f32f03f28eece9ddcdc488a85100c94a7c924c185ae560363518dae5e2aacccb",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "858050.000000",
+								"src_txid": "0f4958d590ed4ac9aca79d848731b358b1c01fab9717775cf6515f2bf2706dc8",
 								"hours": 1829,
 								"calculated_hours": 94784
 							}
@@ -5593,6 +5705,7 @@
 								"uxid": "2987e7c89d353ad5d63cea2bf2724dc5f7a5ef5fb81f5ea160a307f0726ac2f5",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "10.000000",
+								"src_txid": "9fb039cd90a4e9b85669bd6ef878b98a9e84eec7d4804e2bff6f0dc9c2739c44",
 								"hours": 0,
 								"calculated_hours": 701
 							},
@@ -5600,6 +5713,7 @@
 								"uxid": "a52408daa8ce7026c70b61d4df4212fb577462060f340bfce779225b3e18193d",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "10.000000",
+								"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 								"hours": 50058,
 								"calculated_hours": 50605
 							},
@@ -5607,6 +5721,7 @@
 								"uxid": "dc73aac74348dd285a1456c1fae2204d7c2039d50a765bdaae0c31f7c7e059db",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "10.000000",
+								"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 								"hours": 6257,
 								"calculated_hours": 6804
 							},
@@ -5614,6 +5729,7 @@
 								"uxid": "e4e375b9dc55ff53d6de9120f1a87ff00e00a779835f8320f2c6b3090d0466e6",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "10.000000",
+								"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 								"hours": 782,
 								"calculated_hours": 1329
 							},
@@ -5621,6 +5737,7 @@
 								"uxid": "d11b05345917d171f60c31bd2634041b73b97eae364724369ddb8d53369397fb",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "10.000000",
+								"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 								"hours": 97,
 								"calculated_hours": 644
 							}
@@ -5665,6 +5782,7 @@
 								"uxid": "aee4af7e06c24bccc2f87b16d0708bfea68ac1b420f97914965f4a23ad9e11d6",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "23000.000000",
+								"src_txid": "c93f8bb30e75ffbc0075a4baf57a0f536e4a9123395b13ce67af5cd2dd0f8cd4",
 								"hours": 294,
 								"calculated_hours": 701385
 							}
@@ -5709,6 +5827,7 @@
 								"uxid": "6002f3afc7054c0e1161bcf2b4c1d4d1009440751bc1fe806e0eae33291399f4",
 								"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 								"coins": "27000.000000",
+								"src_txid": "0301358c2db5314ca43c442bac3c1daf31f4b39f9ac9e22dc157687212cab703",
 								"hours": 220,
 								"calculated_hours": 823240
 							}
@@ -5753,6 +5872,7 @@
 								"uxid": "4e75b4bced3404590d38ca06440c275d7fd86618a84966a0a1053fb18164e898",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "26700.000000",
+								"src_txid": "a689a3589730a351f880176b2c15b395967b38a90950e0491e7a1e5531f020a9",
 								"hours": 54,
 								"calculated_hours": 811481
 							}
@@ -5797,6 +5917,7 @@
 								"uxid": "0a5603a1a5aeda575aa498cdaec5a4c893a28669dba84163eba2e90db3d9f39d",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "26700.000000",
+								"src_txid": "7b13cab45b52dd2df291ec97cf000bf6ea1b647d6fdf0261a7527578d8b71b9d",
 								"hours": 101435,
 								"calculated_hours": 101435
 							}
@@ -5847,6 +5968,7 @@
 								"uxid": "194cc596d2beda803d8142ddc455872082f84b09a5edd8085082b60d314c1e29",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "23000.000000",
+								"src_txid": "9f20b52befed2cbaaa4a066de7119b7fdbff09a83d8e2a82628671f51f3f6551",
 								"hours": 87673,
 								"calculated_hours": 109842
 							}
@@ -5897,6 +6019,7 @@
 								"uxid": "1e30e9dfe00e055404063e52a4154a72492b13de6acf4871ec5ea6d7c0fcc968",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "26600.000000",
+								"src_txid": "9150311508851ca989efb5f82b5a7201724514b6b9f84ec1620c18673462126b",
 								"hours": 12679,
 								"calculated_hours": 14895
 							}
@@ -5950,6 +6073,7 @@
 								"uxid": "99b4e51e1afd04813656e6202c7e462d88ce87ba980da7a62591190d72d1073c",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "858000.000000",
+								"src_txid": "fe01250cfdf84eb0182c033c216891e7e6971cc85976c4c46d9e3c608974d233",
 								"hours": 11848,
 								"calculated_hours": 962798
 							},
@@ -5957,6 +6081,7 @@
 								"uxid": "f12164a6ea6ce65ff2ca1f2be7251bece8f7c5747ba8ec68e1ec3b27d45d7b9c",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "50.000000",
+								"src_txid": "fe01250cfdf84eb0182c033c216891e7e6971cc85976c4c46d9e3c608974d233",
 								"hours": 11848,
 								"calculated_hours": 11903
 							},
@@ -5964,6 +6089,7 @@
 								"uxid": "427462efeb07a6803f013c789ea43d93240f74f886bf9afd63dc1936a7574a37",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "50.000000",
+								"src_txid": "819106dc50373e5293a7e79f179693e85536e8206d82272930ec08410d92402a",
 								"hours": 7510,
 								"calculated_hours": 7564
 							},
@@ -5971,6 +6097,7 @@
 								"uxid": "f9bffdcbe252acb1c3a8a1e8c99829342ba1963860d5692eebaeb9bcfbcaf274",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "27000.000000",
+								"src_txid": "e8fe5290afba3933389fd5860dca2cbcc81821028be9c65d0bb7cf4e8d2c4c18",
 								"hours": 102905,
 								"calculated_hours": 132080
 							}
@@ -6021,6 +6148,7 @@
 								"uxid": "dfd2834342f3a7caf183472c17801aafacd1775378eb843509d17ad858456cb0",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "885000.000000",
+								"src_txid": "8de17dff34a8798f2ac89584f5c559e3bb82c280a3f6890386b4dbc5fef0e8cf",
 								"hours": 139293,
 								"calculated_hours": 139293
 							}
@@ -6071,6 +6199,7 @@
 								"uxid": "aa1133a42417332af8b58e71cc14a651e2731563eaea35f0feacc1e97fac6eef",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "22900.000000",
+								"src_txid": "44d56cfa9f83d874ee10fb32f0d40458f6bf3e86528592c9a9abf3c960fcb278",
 								"hours": 13730,
 								"calculated_hours": 27660
 							}
@@ -6121,6 +6250,7 @@
 								"uxid": "8ac39d41ec014ca6625e5f17e1fbe62db7a4ac154e0e42a017efa037935ae968",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "884900.000000",
+								"src_txid": "6546dfbe6e61e81f3e9f6c9afdfee1c07758f2e486d731ae4d19b40602367656",
 								"hours": 17411,
 								"calculated_hours": 56739
 							}
@@ -6171,6 +6301,7 @@
 								"uxid": "4326c936322df6d59b3b539ea340eb9630c7f8484eba2aeba1a0ed4d431ab614",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "22800.000000",
+								"src_txid": "a8d6420d4f64fad1b698bd77cae5a92aa125f806fb184389edcc278e5cb460fa",
 								"hours": 3457,
 								"calculated_hours": 142790
 							}
@@ -6221,6 +6352,7 @@
 								"uxid": "f9bf35f993452b3d490668bb579fd272da969a1bcca8de0c25000ee57b5d7f54",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "22700.000000",
+								"src_txid": "552a4b194478325ee9f3e4a8648d94bc8eb26432be6fecc881bf71ff9ca15356",
 								"hours": 17848,
 								"calculated_hours": 17848
 							}
@@ -6272,6 +6404,7 @@
 								"uxid": "bae0e928b795e2a80c88161afcbc102dcad6644386f6f44050dde8d586750140",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "881900.000000",
+								"src_txid": "a4c15ae4743246709ec335d33c289576c8893e71f5c3dcee1db6e43eec9242ee",
 								"hours": 7092,
 								"calculated_hours": 11108253
 							},
@@ -6279,6 +6412,7 @@
 								"uxid": "94889dbe1c20eb942b7932c5301737537ac33abd9c81d72e1642ddc70ce320e0",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "10000.000000",
+								"src_txid": "6ce27da2ddbc15f03330960b4201dbb3a066ad2e9bbd5366a9564f6befdcae2e",
 								"hours": 2231,
 								"calculated_hours": 2231
 							}
@@ -6329,6 +6463,7 @@
 								"uxid": "1d4595b9fa1c6c3d64f48b6ae5f8f861b1c08a022cbcb04b279df448da3db660",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "873900.000000",
+								"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 								"hours": 1388810,
 								"calculated_hours": 1388810
 							}
@@ -6379,6 +6514,7 @@
 								"uxid": "412eff3eef889c682da8db3608fce37d1c5ee2cc297bc88d901648e6ccd418f9",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "873800.000000",
+								"src_txid": "1f27afc41896d2c7fdbd2620e606440ad12557e9a4bdd6808dcc2c23d4e32978",
 								"hours": 173601,
 								"calculated_hours": 173601
 							}
@@ -6429,6 +6565,7 @@
 								"uxid": "6ad7993fb2728c2c53ac2c8395a6c62d03c5ef9298ca467e7998fb64fd0c90b4",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "873700.000000",
+								"src_txid": "e8765b4e6fbca87144df59a6f66815b175e81999509504b117636edc34cbe2af",
 								"hours": 21700,
 								"calculated_hours": 21700
 							}
@@ -6479,6 +6616,7 @@
 								"uxid": "2426f768e00345b641f5b4b4b058c308d528e22437bc6e552f0a9d5bd665e14a",
 								"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 								"coins": "26500.000000",
+								"src_txid": "41ec724bd40c852096379d1ae57d3f27606877fa95ac9c082fbf63900e6c5cb5",
 								"hours": 1861,
 								"calculated_hours": 518287
 							}
@@ -6529,6 +6667,7 @@
 								"uxid": "0976005ab4540e8211cd929f19634bfaa2f5d8e24177ddb5b803b447ea91f8c3",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "873600.000000",
+								"src_txid": "bb700553c3e1a32346912ab311fa38793d929f311daeee0b167fa81c1369717e",
 								"hours": 2712,
 								"calculated_hours": 167725
 							}
@@ -6580,6 +6719,7 @@
 								"uxid": "7b132c07322babefa83ab64971b7bfb29bf2cb9ffe9c42dc7e2975a185dcd8b8",
 								"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 								"coins": "995.000000",
+								"src_txid": "a95317361364e8cc08a150840bac8a97ea1f56278f8834ca2a2f16c24c4a7f0f",
 								"hours": 387,
 								"calculated_hours": 72454
 							},
@@ -6587,6 +6727,7 @@
 								"uxid": "c961ba554ae30b0edcdf71e834ab2b26d7dff5bcf5955d4874cdba89170392bf",
 								"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 								"coins": "100.000000",
+								"src_txid": "1f27afc41896d2c7fdbd2620e606440ad12557e9a4bdd6808dcc2c23d4e32978",
 								"hours": 173601,
 								"calculated_hours": 173704
 							}
@@ -6637,6 +6778,7 @@
 								"uxid": "ba0a94662846565969d361b1b7c248847a48e69f2b9eefb4ffb0bc2efc56a8fd",
 								"owner": "38cVLswijqC2ANV5HxTroeapQzqeoBR88C",
 								"coins": "50.000000",
+								"src_txid": "a83e09e976b038d86491d8c029aec84a6313dc33e692da6ce50a2858e50c4666",
 								"hours": 30769,
 								"calculated_hours": 30769
 							}
@@ -6687,6 +6829,7 @@
 								"uxid": "f480c6097568036b90a2e019f9ee68c0812b2da8828be33a005a7427caf14a2b",
 								"owner": "f38daJDg8rpwL5xWgMY78fBHncQ1N5gQZ7",
 								"coins": "38.000000",
+								"src_txid": "4d080ff1f8ac21d8c09a2dca99d28ae88e9441d7a4757dca68469ad64838cb55",
 								"hours": 3846,
 								"calculated_hours": 3846
 							}
@@ -6731,6 +6874,7 @@
 								"uxid": "6beca9fb58a327580c614d7fb5622916849756790b661bcabc880666364fdf47",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "863600.000000",
+								"src_txid": "345488861ad3f0d93024c367990e64ef0f7a95bd8b8589f554172f9439808263",
 								"hours": 20965,
 								"calculated_hours": 3029171
 							}
@@ -6781,6 +6925,7 @@
 								"uxid": "f8a1990492f970227ec29e6e095fa724d66fa2d6883bd8723773098d08ca8b3c",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "801600.000000",
+								"src_txid": "da82deafc15c36e7dc9cd95663e0dc910ae626ee543147ac7bd8682be00f7baf",
 								"hours": 378646,
 								"calculated_hours": 378646
 							}
@@ -6831,6 +6976,7 @@
 								"uxid": "998487775c0e58420673b70204b83c1d6bb5b70e34b1aa0f8169c85ecec2438e",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "765600.000000",
+								"src_txid": "211f5fc97ba1797d78f84d4e4db78415b5ff4121f78369535fe3f8015571c6df",
 								"hours": 47330,
 								"calculated_hours": 47330
 							}
@@ -6881,6 +7027,7 @@
 								"uxid": "6fb116c110fe391448a1dcb985b67439c2e9a71d8bb2fd1cf345ac73ada6166a",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "755600.000000",
+								"src_txid": "9003d3caba9587d46d000cc614bb52bed34adcc5ea404c560c986eb6dd756e6b",
 								"hours": 5916,
 								"calculated_hours": 5916
 							}
@@ -6931,6 +7078,7 @@
 								"uxid": "04471fb0797bb931e883f7b95cfff6ee4fea5e19a352ca5425fcd353c4f6aba4",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "750600.000000",
+								"src_txid": "e9a6dd585b564b19c55d9f56188a45bfad32fa75703fa6336830035f6fa92e3d",
 								"hours": 739,
 								"calculated_hours": 739
 							}
@@ -6982,6 +7130,7 @@
 								"uxid": "e2512ec90800147d0d9ddbd0778511ee5a45a25efcb354c50a101738a65462c5",
 								"owner": "YLT4buWf3kYDV9QddnC5iXTj881Eniuvrx",
 								"coins": "300.000000",
+								"src_txid": "8374d85130bbcf496bff138cd040f91fa362eb1b6b6a1c7c9285523437d5589c",
 								"hours": 3436,
 								"calculated_hours": 37891
 							},
@@ -6989,6 +7138,7 @@
 								"uxid": "6e2abc4bc7820178358a603b7d99c4b39735dd1685d0c5a778ab63f29c9e93d9",
 								"owner": "YLT4buWf3kYDV9QddnC5iXTj881Eniuvrx",
 								"coins": "700.000000",
+								"src_txid": "b7b42b1b29acab0a2328aaf368ec74be49b4d4caf827e82b439ef4d8be976a55",
 								"hours": 20200,
 								"calculated_hours": 100590
 							}
@@ -7040,6 +7190,7 @@
 								"uxid": "c5df36ce47f6f183475317ab1c53eaa65428c142cb3e3906bf162d80519a203f",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "12700.000000",
+								"src_txid": "6ce27da2ddbc15f03330960b4201dbb3a066ad2e9bbd5366a9564f6befdcae2e",
 								"hours": 2231,
 								"calculated_hours": 1175478
 							},
@@ -7047,6 +7198,7 @@
 								"uxid": "53b376413d550663ab51b229df8b0f55e4055d6577c2d8b5cec8ff748fe0e958",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "18000.000000",
+								"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 								"hours": 1388810,
 								"calculated_hours": 3051530
 							}
@@ -7098,6 +7250,7 @@
 								"uxid": "6b616ad99a946538c3ab101f245bcab211ab39507848425e80cbfc8ec5bdbc67",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "738100.000000",
+								"src_txid": "1ca0a2d44b6439b91eb839e0f99405abdcafe2c1a49c8b49b1739498129bd1a6",
 								"hours": 92,
 								"calculated_hours": 55430171
 							},
@@ -7105,6 +7258,7 @@
 								"uxid": "ef488d5f4a019502115d3b6b50bd364692315c3954d7e93c3ca22e11b92fc528",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "100.000000",
+								"src_txid": "243e1baa955c3f0af42d7acc4c920437dd0a99c754d6c5c2b7defcd143ff288d",
 								"hours": 528376,
 								"calculated_hours": 528376
 							}
@@ -7155,6 +7309,7 @@
 								"uxid": "8169bf7f8fa21dc6400b60678b302946cf2765f44893ec8466262fc69b710591",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "30600.000000",
+								"src_txid": "243e1baa955c3f0af42d7acc4c920437dd0a99c754d6c5c2b7defcd143ff288d",
 								"hours": 528376,
 								"calculated_hours": 534836
 							}
@@ -7205,6 +7360,7 @@
 								"uxid": "78126a08c4dd4ea7ca2d6c9f9d4614fa58896ec4ea301cb9b450104b00bc1b94",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "29600.000000",
+								"src_txid": "66d415598af081f8a7bd7f292468e67f380d06bf5896eb8152d4d9e8bcdf289e",
 								"hours": 66854,
 								"calculated_hours": 66854
 							}
@@ -7255,6 +7411,7 @@
 								"uxid": "ecb92dc2f43d4c6ca124575d8456d8894f3cb137875287beaa73180fcae2b3ca",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "737200.000000",
+								"src_txid": "c2c9fe882df3b44fbb125b251a7604a7a4f4195dddff6e5396b7f130744e2b27",
 								"hours": 6994818,
 								"calculated_hours": 101676076
 							}
@@ -7305,6 +7462,7 @@
 								"uxid": "6b4ca83b3f73b62161c90c6da03dff460ca9a5a3ccd6fafca140137416dedc58",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "736000.000000",
+								"src_txid": "6538399868cf772fcfa96e68c51aa6aa66faa95d7c685432e4005880932be134",
 								"hours": 12709509,
 								"calculated_hours": 12709509
 							}
@@ -7355,6 +7513,7 @@
 								"uxid": "2cd58783beb8a9f6278f7a097151531091b5f15afd7735e1facf02aa720c1191",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "735000.000000",
+								"src_txid": "3dfdfea4614d05c2f5eddf5773ef0afc745f1afe585141659df8e03e82897606",
 								"hours": 1588688,
 								"calculated_hours": 1588688
 							}
@@ -7405,6 +7564,7 @@
 								"uxid": "52288a441c70260f6a3eab0e271969d54492377615a6fba8ec3ad26f11dc9768",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "734500.000000",
+								"src_txid": "d30cec3ad3a66562d2513a3656b366ea7da583e6ba45214ac12b9c2219b4c5ea",
 								"hours": 198586,
 								"calculated_hours": 198586
 							}
@@ -7455,6 +7615,7 @@
 								"uxid": "e29ec214f4afd79e6465d03e4d88e552dc69654750a725d74873ee366c58e552",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "734400.000000",
+								"src_txid": "44d05abc2637d9cd2047984023eb5cfa0a146e58821117de30f9c81703189cde",
 								"hours": 24823,
 								"calculated_hours": 24823
 							}
@@ -7505,6 +7666,7 @@
 								"uxid": "8ea58a3736b35f0e3781e94198e8b73bba2536704b84b15900fb32701db8893e",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "733400.000000",
+								"src_txid": "072f0738f834db0030d777e6ec0e0443627c51cecffcc55e41d43b0b8edd40d1",
 								"hours": 3102,
 								"calculated_hours": 3102
 							}
@@ -7555,6 +7717,7 @@
 								"uxid": "a1ed39cded6d9a0605b52f25cbedb363e57a168d1ad1d1db437816a401c061ab",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "732400.000000",
+								"src_txid": "b9a795552bec1a722718b44a08ad152656242b1d23afb53d2247b3016d920b7e",
 								"hours": 387,
 								"calculated_hours": 387
 							}
@@ -7605,6 +7768,7 @@
 								"uxid": "f89c968840831d03abaf3c41cf8a405e4b4ddbfb19f5ba300a8ea8e4dcb1d9a4",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "731400.000000",
+								"src_txid": "fc02772662176c282c2b6538732d3d6eb1399f006a0b52e64d07fc104038f638",
 								"hours": 48,
 								"calculated_hours": 48
 							}
@@ -7655,6 +7819,7 @@
 								"uxid": "36972dc046829caa340eaecbfeb42f4174bcdecfb87296d56503e5fb10e9de8d",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "730200.000000",
+								"src_txid": "9880bebc51471e0b3c520920db836d674f652503314cd74069a59ccad0d0967a",
 								"hours": 6,
 								"calculated_hours": 6
 							}
@@ -7705,6 +7870,7 @@
 								"uxid": "6962c7c1fcc98f532a9003990163bb251811a4700257968a641b1fe975cfc51d",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "729200.000000",
+								"src_txid": "578075959959db70ae86f4f60d2ae3ff245727d086eef86ed80db5e1c7c9fbaf",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -7755,6 +7921,7 @@
 								"uxid": "d53fae3b48bde2d1328964a2e7f42e8e833983db159ba30f627926dea0db7df0",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "728200.000000",
+								"src_txid": "de45a24c9c32f808a3d928f30ba8e1b6ef8117a7c0b7a5d616734d9b121d0c30",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -7805,6 +7972,7 @@
 								"uxid": "228794e6b3eb69aecc5334e140afbad22883326dcf229bd3092f238ed9ec800f",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "725700.000000",
+								"src_txid": "16f8b9369f76ef6a0c1ecf82e1c18d5bc8ae5ef8b01b6530096cb1ff70bbd3fd",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -7855,6 +8023,7 @@
 								"uxid": "6efc30b4c943ba4de8d2c89901a0b2a4d9a0ecf34713917eae37c6debca616ed",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "724700.000000",
+								"src_txid": "030177271beee04f1a0974d0c5042f07c7ca1db1c5d496fbee3c441b1b7c5bee",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -7905,6 +8074,7 @@
 								"uxid": "6c8b1ba9dc7e8900b42d55e9fbe6ea0e00d7eaccf67a7b66c0a2b771cf88ea05",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "724200.000000",
+								"src_txid": "57150aecde96bde972183b9b0d7d27dda2c0179fb71630e92c27856d211335cd",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -7956,6 +8126,7 @@
 								"uxid": "c2fcd55cf6b73e863c96f7c2d6251069199bfd43688d2515f5c6631688aadcbc",
 								"owner": "bNQHMc2nM8x2fssmyUp6QWY1ow6LzB7kZz",
 								"coins": "1000.000000",
+								"src_txid": "e3b7236ad4b209d664ee1e2549f2a0d34a3ba58b12ee46f98fba73c01574e484",
 								"hours": 5,
 								"calculated_hours": 396519
 							},
@@ -7963,6 +8134,7 @@
 								"uxid": "06292fe8a2036c38f28c4d2f355d9e86e2b55b9d85f84613a64cf5c35d192b28",
 								"owner": "bNQHMc2nM8x2fssmyUp6QWY1ow6LzB7kZz",
 								"coins": "1000.000000",
+								"src_txid": "bbd1d4b6fe89a5986efbea9f7996cca2a515c3f0788cedccc21990dc78d83509",
 								"hours": 43,
 								"calculated_hours": 396554
 							}
@@ -8007,6 +8179,7 @@
 								"uxid": "59d44fefbe86ebae4118dee90609d6a1c08c36f259c65e3fad63b9e41c37bf0c",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "723200.000000",
+								"src_txid": "3bb9fc516dc2c522e28f99e6833253863c550547ce0e0a2dd963a0118b7a44a7",
 								"hours": 0,
 								"calculated_hours": 9192675
 							}
@@ -8057,6 +8230,7 @@
 								"uxid": "5baf8c8ab1a01d80a6f496144815cf6bda5289b34055010e21324ea3950d3299",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "722200.000000",
+								"src_txid": "5701965d326520f86335da87c6d1781fd49f1e66520b94e1783711eba724f482",
 								"hours": 1149084,
 								"calculated_hours": 1149084
 							}
@@ -8107,6 +8281,7 @@
 								"uxid": "dd07d759d92e3d628a35c467dcd919dcae825a9fa79a14855714270dae08c0ce",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "721200.000000",
+								"src_txid": "3fae944ef07d9bcba1bcbc8bde87da50a1232132074803f8442deb563ed2da51",
 								"hours": 143635,
 								"calculated_hours": 143635
 							}
@@ -8157,6 +8332,7 @@
 								"uxid": "c739b518f3f700e810f81523d81b15f968fbf202f389ceaa9d9f303319a00275",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "720200.000000",
+								"src_txid": "79681167a7681edecb998e4a6dccdd0b7be45f163c8f6db23436517936269fb8",
 								"hours": 17954,
 								"calculated_hours": 17954
 							}
@@ -8207,6 +8383,7 @@
 								"uxid": "95694746f813d018be7988aec666b52924a7815adabe9cbdac3f6ab0f51bd1ab",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "719200.000000",
+								"src_txid": "b69536fbec9911da41e9d0c5ca73459f5e692ba155f8b72c0972792e9937a0fe",
 								"hours": 2244,
 								"calculated_hours": 2244
 							}
@@ -8257,6 +8434,7 @@
 								"uxid": "be958e5c47415291a781648335db24e448e1f4f09aa5e9c3f055fbc906b574d7",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "719100.000000",
+								"src_txid": "3e228564e3c187e22bd489857fdb1db7036021e19f688aad56cfee57d5e13ac5",
 								"hours": 280,
 								"calculated_hours": 280
 							}
@@ -8307,6 +8485,7 @@
 								"uxid": "68165429853e18e4414ec6c15630262ebcaa802ff1d83b6cbe116db51cb32066",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "718100.000000",
+								"src_txid": "18607765c3fbd45eafa15d2d62ab3cbc7ba7bd80c42931aae4db75aa02898671",
 								"hours": 35,
 								"calculated_hours": 35
 							}
@@ -8357,6 +8536,7 @@
 								"uxid": "46aeb9ea01bb04e28c55ef11f8e75434dbeee546f7e06bdef332c604590c48a1",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "717100.000000",
+								"src_txid": "dc10e0565a14dfecda066577581f3e2d073de34ed3e911ed94413d38fc0a33d2",
 								"hours": 4,
 								"calculated_hours": 4
 							}
@@ -8407,6 +8587,7 @@
 								"uxid": "598503902d2e6cb62d6f6478f09d8da05af6fd2da92b50825da3b7f74b2df34c",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "716100.000000",
+								"src_txid": "b0d7ff47658b3e32d8457eb62f6df0c7caaf7feadcbf8cc0c713976026f0404c",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8457,6 +8638,7 @@
 								"uxid": "4b917e7bd3409c43f9f670f2846ce74f9288708df5aa1d9ae142f2411ce426da",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "715100.000000",
+								"src_txid": "be0957035ed2ac444f67273fc5c1c6a39ee373f6f83d1604d0023742a8cd7e42",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8507,6 +8689,7 @@
 								"uxid": "d50a372f8f8cd1e0b10d847613b68ee760f195f5f212d6c59e86312c84dd07ac",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "714800.000000",
+								"src_txid": "c9582c8134fa64fdf08cd93d42035adcced3f16aa8ee1a1393e3fcd7c07aa40c",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8557,6 +8740,7 @@
 								"uxid": "896865f9b610f9fb69a741596b3ecb9fff3790d40476a9f7852831bdf477aaee",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "713800.000000",
+								"src_txid": "29a883ef9dc67bc683014187b9865c827b5e2f8afd7bf6f3787483318063789e",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8607,6 +8791,7 @@
 								"uxid": "272d5bbd86a87796a20e3e4debc46a2076718800343bee4f72fc0217a98a10a3",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "695800.000000",
+								"src_txid": "c3fd04cd27ea311b1a67d40cd3dbb2ea8ae2c6f6139620cb86be29f33ed99171",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8657,6 +8842,7 @@
 								"uxid": "60906201d3e7c67ddb976972460b2b8ed093e1f6720a784cbaea376ca13e6cef",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "670800.000000",
+								"src_txid": "3d9f1aa1b6206275081cb9c26155f6261be1ef9c94b4eaadb1a7e8277a2099fa",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8707,6 +8893,7 @@
 								"uxid": "4912e9dbbb5a4cc7472c27b0212ab443e7b5499207b10666a66257005e182714",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "664464.000000",
+								"src_txid": "d720ca0efb19b964f481724e5d3f932841e9e75a69b998baf4b575cf3298cb87",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8757,6 +8944,7 @@
 								"uxid": "659bac1636b64087ad5d3cb0ae78c52f28ad920016ec67e08415a537e0343072",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "663464.000000",
+								"src_txid": "0e8e352b1f2cd419bca619918ce6d5ec1eac0ba7252d76eef5d9d8f8186f737a",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8807,6 +8995,7 @@
 								"uxid": "97f64c3c636e5fc997e277cd48644055ef51045ed9c473c05dd6e699872a6c3d",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "662464.000000",
+								"src_txid": "d5091ca65ff61998dfb4535a7927fb736abf2a81140a11322dcf8226de27cf92",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8857,6 +9046,7 @@
 								"uxid": "122b7a9a61ee04e071002d74ffb26b12ed7952ff9a138b5437f990f4678cc2e5",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "662314.000000",
+								"src_txid": "30e66ff45cfb145eb465e2ebdef0bb10005138bc1727c83888785b04d548e85b",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8907,6 +9097,7 @@
 								"uxid": "c07593d4329f82da243e4bbd7430e4b10e7b35f9ce0a3718d0e6d25d20b4939b",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "661314.000000",
+								"src_txid": "ec79854fade530d84099d5619864a8e1e8ec9d27a086917a239500cada43c6e8",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -8957,6 +9148,7 @@
 								"uxid": "4d52106e41dba0099549fd81fb8feb6915225b0125c53faa0f7c578ea78f213a",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "660314.000000",
+								"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -9008,6 +9200,7 @@
 								"uxid": "37cc43693a024f9122f5e1fcabeab5d53a4d58590df30a934fc7bc545936e049",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "1000.000000",
+								"src_txid": "2df67e974b03b46be4e59fcf2f8b751d501f17f8610d5adf94551a7ecc6a58af",
 								"hours": 8356,
 								"calculated_hours": 141306
 							},
@@ -9015,6 +9208,7 @@
 								"uxid": "903a1bca9b81ed76179cbcffe6e3c8eff269c94826148286f7be0b6038ee4ccb",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "28600.000000",
+								"src_txid": "2df67e974b03b46be4e59fcf2f8b751d501f17f8610d5adf94551a7ecc6a58af",
 								"hours": 8356,
 								"calculated_hours": 3810733
 							}
@@ -9065,6 +9259,7 @@
 								"uxid": "fef9dd3b633274743099e607d9229717a001d6de6a4031479cc30d31d65e8396",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "659314.000000",
+								"src_txid": "3991a257eee265481e713917a3a9c15756f61175bcfc7acfdbe84158e43fd5e6",
 								"hours": 0,
 								"calculated_hours": 269219
 							}
@@ -9115,6 +9310,7 @@
 								"uxid": "21f0fb666dca05d7a43ab26a378f7f7eaedfacde22fa047ca72857e9509cc748",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "659214.000000",
+								"src_txid": "b29222c08f10b8bc4ea18981519a3b0e02b9c9cec63ee28d9ffa2efcaf2a8e5a",
 								"hours": 33652,
 								"calculated_hours": 33652
 							}
@@ -9165,6 +9361,7 @@
 								"uxid": "bc513a68461d5c401e65a500baf7dfa163735ef63b817bb7b73c4139d5c29d18",
 								"owner": "212mwY3Dmey6vwnWpiph99zzCmopXTqeVEN",
 								"coins": "1000.000000",
+								"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 								"hours": 0,
 								"calculated_hours": 561
 							}
@@ -9215,6 +9412,7 @@
 								"uxid": "bffea1990d71311b695b2d343b9f09a216b7a8257c1cdcb01b2ab9459e1490e3",
 								"owner": "jtuSERvfzN3kUYekg8LemCQ5kF5g97N8ZL",
 								"coins": "10.000000",
+								"src_txid": "acfb61f7ca39d5dfe33e8ed66f73ab181da0a3206d457bf055dcc4b9731a3ec8",
 								"hours": 70,
 								"calculated_hours": 70
 							}
@@ -9259,6 +9457,7 @@
 								"uxid": "6b3a0cab1d9ad6fd011a3bac5e6ff4e3f7903bce911dc7fe83926eae557c34c3",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "658214.000000",
+								"src_txid": "50fc81b0ba25669105a169a969459ccdb10278051b604a3f91467c2528c83652",
 								"hours": 4206,
 								"calculated_hours": 8113036
 							}
@@ -9309,6 +9508,7 @@
 								"uxid": "074645413ab2aae818e657f6f36420447a872e7cdd2ff64324b486be4d4d1edd",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "29100.000000",
+								"src_txid": "41589644ea3a344fc616bec0058cf916b8efa5da7c3539241244827bd7e19811",
 								"hours": 494004,
 								"calculated_hours": 1132102
 							}
@@ -9359,6 +9559,7 @@
 								"uxid": "372703f8109295f0f58fbee58795979e10dd887869f4fc1da4881ce8a3c0aeb4",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "647750.000000",
+								"src_txid": "fb495093f2f4e5c6555c50150ea60c0a6f430e53aa971ebb3e2b5412866a1f06",
 								"hours": 1014129,
 								"calculated_hours": 1019526
 							}
@@ -9409,6 +9610,7 @@
 								"uxid": "b1b832a911d45aeaab73676caad794fe2ab99d423f80c4ff58cfb269656b03dd",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "28100.000000",
+								"src_txid": "7abef7e4080bf2cbe9f147d7c9cbe4c950b38f8477d304466c938b937cd379ba",
 								"hours": 141512,
 								"calculated_hours": 148693
 							}
@@ -9459,6 +9661,7 @@
 								"uxid": "14027340f6e1d98bba3f7f5f3b50e3588f8a19e4d021db944e7a28b2643640e1",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "635750.000000",
+								"src_txid": "a7665cec98224150968ec1ef9ef2d6b3175c9de8f9f8c7bc786b30cc74997c57",
 								"hours": 127440,
 								"calculated_hours": 146865
 							}
@@ -9522,6 +9725,7 @@
 								"uxid": "04c0cd4cbee1e5414791d9e0b9ae4f889bc52d253b5f70b09fbc32c88fb415ae",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "3.000000",
+								"src_txid": "fa33df7c4316cea05095e6c7ce86f361847893d26fe2255af118593a33686c52",
 								"hours": 4,
 								"calculated_hours": 1748
 							},
@@ -9529,6 +9733,7 @@
 								"uxid": "f3034ffe54e869315f8e11801d3e755352fb75b878b24313302273c1b7ea62cb",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1.000000",
+								"src_txid": "fa33df7c4316cea05095e6c7ce86f361847893d26fe2255af118593a33686c52",
 								"hours": 0,
 								"calculated_hours": 581
 							},
@@ -9536,6 +9741,7 @@
 								"uxid": "3538af0016ec0f4d0e943c5d49daf280b416701fde4040fa72710c0ca1b5b559",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1.000000",
+								"src_txid": "b68d78c9a4610b540933eaa550fbb1c473f5cf749eb522882f8154d495453e7d",
 								"hours": 0,
 								"calculated_hours": 581
 							},
@@ -9543,6 +9749,7 @@
 								"uxid": "0560bae3917bca7581af9b6c5a58e395c701ce9ed0241dac2de8a3e93c0b839b",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "77a69f4c8afd858a2f6767bb9980d4af6520e02b076bf2a78b935021e1147c71",
 								"hours": 1605,
 								"calculated_hours": 510237
 							},
@@ -9550,6 +9757,7 @@
 								"uxid": "3fe7d61ffa993e00200ce6be7ba347c603032ac3f8c4ace07767e630fe94d76c",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "0cded82aa3ac92d78e23d2d0d7faf93c675fc9a321ad55105f65b6fca444b1e7",
 								"hours": 125696,
 								"calculated_hours": 610213
 							},
@@ -9557,6 +9765,7 @@
 								"uxid": "2a09e97f7725a35af1357842206875a023252da4ebfce129eaf4cb87119cfd41",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "bd617ec27c2bea642fad8c153178e11ca08456d752249324e3011f27c845f87a",
 								"hours": 2704,
 								"calculated_hours": 487118
 							},
@@ -9564,6 +9773,7 @@
 								"uxid": "617b584bb9e6b1d80daac915fb3079b22a326777d1515a40e7b7eddf427f4099",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "072f0738f834db0030d777e6ec0e0443627c51cecffcc55e41d43b0b8edd40d1",
 								"hours": 3102,
 								"calculated_hours": 163688
 							},
@@ -9571,6 +9781,7 @@
 								"uxid": "18293d947aadf89d9e57d18fa01408867a9abe267504edbdabf8c2a57d9a6323",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "030177271beee04f1a0974d0c5042f07c7ca1db1c5d496fbee3c441b1b7c5bee",
 								"hours": 0,
 								"calculated_hours": 112148
 							},
@@ -9578,6 +9789,7 @@
 								"uxid": "045dc2e76321e37884588093083ce1b21be12f20ba1fa36f2a755b894229e3cf",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "b0d7ff47658b3e32d8457eb62f6df0c7caaf7feadcbf8cc0c713976026f0404c",
 								"hours": 0,
 								"calculated_hours": 73857
 							},
@@ -9585,6 +9797,7 @@
 								"uxid": "b1e5c694c30326cda3df2e634723999befbcbb141415e9a36bdbf18d7bea9870",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "6336.000000",
+								"src_txid": "d720ca0efb19b964f481724e5d3f932841e9e75a69b998baf4b575cf3298cb87",
 								"hours": 0,
 								"calculated_hours": 340570
 							},
@@ -9592,6 +9805,7 @@
 								"uxid": "db7a63750db787959a9e0d2d6be9a1ba8bb3d6015bae2353a27ae9eb55b39d22",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "150.000000",
+								"src_txid": "30e66ff45cfb145eb465e2ebdef0bb10005138bc1727c83888785b04d548e85b",
 								"hours": 0,
 								"calculated_hours": 5180
 							},
@@ -9599,6 +9813,7 @@
 								"uxid": "5954742a6ca4e3e872d12d4a93436451ad52e6d25e5ac28371e308b2d7ce75a3",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "3991a257eee265481e713917a3a9c15756f61175bcfc7acfdbe84158e43fd5e6",
 								"hours": 0,
 								"calculated_hours": 32930
 							},
@@ -9606,6 +9821,7 @@
 								"uxid": "a35044035cce79cb988c757dcaf5d9a065957c0fbc1a3559d08ed46831504fc2",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "10464.000000",
+								"src_txid": "fb495093f2f4e5c6555c50150ea60c0a6f430e53aa971ebb3e2b5412866a1f06",
 								"hours": 1014129,
 								"calculated_hours": 1124989
 							},
@@ -9613,6 +9829,7 @@
 								"uxid": "c31c199a54ecbea5e57bf7f5e73d231a09e11713dd0ee70e340e4b0a9c9f9fdc",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "7abef7e4080bf2cbe9f147d7c9cbe4c950b38f8477d304466c938b937cd379ba",
 								"hours": 141512,
 								"calculated_hours": 152098
 							}
@@ -9663,6 +9880,7 @@
 								"uxid": "d6735d3ad70dbf553048faf1c529d047ab12282d04e320bd67c915779fc4e3fd",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "24950.000000",
+								"src_txid": "a17cf54c20ac7ec6e1362acf24c5e5589ed8b49bdba791a87430de160a473913",
 								"hours": 451992,
 								"calculated_hours": 451992
 							}
@@ -9713,6 +9931,7 @@
 								"uxid": "a5f3c513b5a01dc5e943a5cae91f54b54cde55e984a9480d68d690f40dfb7914",
 								"owner": "v4qF7Ceq276tZpTS3HKsZbDguMAcAGAG1q",
 								"coins": "5.000000",
+								"src_txid": "a17cf54c20ac7ec6e1362acf24c5e5589ed8b49bdba791a87430de160a473913",
 								"hours": 451992,
 								"calculated_hours": 451992
 							}
@@ -9757,6 +9976,7 @@
 								"uxid": "8e55f10a0615a0737e6906132e09ac08a206971ba4b656f004acc7f4b7889bc8",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "625750.000000",
+								"src_txid": "9364ed6cfcc289df74dc6bac1993f7ab3441b898cb3f06918198d2476c83dbac",
 								"hours": 18358,
 								"calculated_hours": 44173190
 							}
@@ -9807,6 +10027,7 @@
 								"uxid": "c39acd3494113650c1a6a7809287af7b12a78bbd97126d4585dd1715e2cb5a66",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "23100.000000",
+								"src_txid": "ad44a8027a825e82a20cdd910d9bd41d74025601b7668c80655e9b45afb8bb93",
 								"hours": 18586,
 								"calculated_hours": 3020347
 							}

--- a/src/api/integration/testdata/blocks-verbose-first-1.golden
+++ b/src/api/integration/testdata/blocks-verbose-first-1.golden
@@ -27,6 +27,7 @@
 								"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "100000000.000000",
+								"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 								"hours": 100000000000000,
 								"calculated_hours": 100000000000000
 							}

--- a/src/api/integration/testdata/blocks-verbose-first-10.golden
+++ b/src/api/integration/testdata/blocks-verbose-first-10.golden
@@ -27,6 +27,7 @@
 								"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 								"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 								"coins": "100000000.000000",
+								"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 								"hours": 100000000000000,
 								"calculated_hours": 100000000000000
 							}
@@ -665,6 +666,7 @@
 								"uxid": "e3e72ee077c8b0c3f87da7cf50cad8876bd3f489f373d9fe82fc2e971df56f76",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "1000000.000000",
+								"src_txid": "86564b421cd3d4fe6f5f2d7a3e5db9d6fc340892bddd3a150533dff7036d0efe",
 								"hours": 1,
 								"calculated_hours": 1
 							}
@@ -715,6 +717,7 @@
 								"uxid": "af0b2c1cc882a56b6c0c06e99e7d2731413b988329a2c47a5c2aa8be589b707a",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "10.000000",
+								"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -759,6 +762,7 @@
 								"uxid": "0cd548e03bd13bca8647cd13f6baef0c65fd03081aeb6dc3695536e5bc6018ae",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999990.000000",
+								"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 								"hours": 1,
 								"calculated_hours": 5556
 							}
@@ -810,6 +814,7 @@
 								"uxid": "9eb7954461ba0256c9054fe38c00c66e60428dccf900a62e74b9fe39310aea13",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "10.000000",
+								"src_txid": "a6a709e9388a4d67a47d262b11da5f804eddd9d67acc4a3e450f7a567bdc1619",
 								"hours": 0,
 								"calculated_hours": 2405
 							},
@@ -817,6 +822,7 @@
 								"uxid": "706f82c481906108880d79372ab5c126d32ecc98cf3f7c74cf33f5fda49dcf70",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "999980.000000",
+								"src_txid": "c24b92898381fbebe59a457924184f4cce1e7166e140ca75aea5baf854c1ab75",
 								"hours": 3704,
 								"calculated_hours": 3704
 							}
@@ -867,6 +873,7 @@
 								"uxid": "dc63c680f408c4e646037966189383a5d50eda34e666c2a0c75c0c6bf13b71a1",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "100.000000",
+								"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -917,6 +924,7 @@
 								"uxid": "8ff8a647e4542fab01e078ac467b2c9f2e5f7de55d77ec2711f8abc718e2c91b",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "95.000000",
+								"src_txid": "03b3ab821cdaf0ab8cc1a9e2dd30108772ec3bda09e9d3a8c48df9f30d213b38",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -967,6 +975,7 @@
 								"uxid": "17090c40091d009d6a684043d3be2e9cb1dc60a664a9c2e388af1f3a7345724b",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "90.000000",
+								"src_txid": "f832428481690fa918d6d29946e191f2c8c89b2388a906e0c53dceee6070a24b",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1017,6 +1026,7 @@
 								"uxid": "999cc56deae71486a28e19d1ed8d585c2cf07d5ee27d1c33bea186d23aaca06a",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "85.000000",
+								"src_txid": "7229422f3a0afb5f3a9596ed50146440c17a3d54abda0f3c70cd9dc58de96374",
 								"hours": 0,
 								"calculated_hours": 0
 							}
@@ -1067,6 +1077,7 @@
 								"uxid": "2f87d77c2a7d00b547db1af50e0ba04bafc5b05711e4939e9ec2640a21127dc0",
 								"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 								"coins": "80.000000",
+								"src_txid": "9d87d7bb9e56a3588bacb478c7556280b28c0a49f6e09db8b54a84c20d865f2f",
 								"hours": 0,
 								"calculated_hours": 0
 							}

--- a/src/api/integration/testdata/blocks-verbose-last-10.golden
+++ b/src/api/integration/testdata/blocks-verbose-last-10.golden
@@ -27,6 +27,7 @@
 								"uxid": "bffea1990d71311b695b2d343b9f09a216b7a8257c1cdcb01b2ab9459e1490e3",
 								"owner": "jtuSERvfzN3kUYekg8LemCQ5kF5g97N8ZL",
 								"coins": "10.000000",
+								"src_txid": "acfb61f7ca39d5dfe33e8ed66f73ab181da0a3206d457bf055dcc4b9731a3ec8",
 								"hours": 70,
 								"calculated_hours": 70
 							}
@@ -71,6 +72,7 @@
 								"uxid": "6b3a0cab1d9ad6fd011a3bac5e6ff4e3f7903bce911dc7fe83926eae557c34c3",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "658214.000000",
+								"src_txid": "50fc81b0ba25669105a169a969459ccdb10278051b604a3f91467c2528c83652",
 								"hours": 4206,
 								"calculated_hours": 8113036
 							}
@@ -121,6 +123,7 @@
 								"uxid": "074645413ab2aae818e657f6f36420447a872e7cdd2ff64324b486be4d4d1edd",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "29100.000000",
+								"src_txid": "41589644ea3a344fc616bec0058cf916b8efa5da7c3539241244827bd7e19811",
 								"hours": 494004,
 								"calculated_hours": 1132102
 							}
@@ -171,6 +174,7 @@
 								"uxid": "372703f8109295f0f58fbee58795979e10dd887869f4fc1da4881ce8a3c0aeb4",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "647750.000000",
+								"src_txid": "fb495093f2f4e5c6555c50150ea60c0a6f430e53aa971ebb3e2b5412866a1f06",
 								"hours": 1014129,
 								"calculated_hours": 1019526
 							}
@@ -221,6 +225,7 @@
 								"uxid": "b1b832a911d45aeaab73676caad794fe2ab99d423f80c4ff58cfb269656b03dd",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "28100.000000",
+								"src_txid": "7abef7e4080bf2cbe9f147d7c9cbe4c950b38f8477d304466c938b937cd379ba",
 								"hours": 141512,
 								"calculated_hours": 148693
 							}
@@ -271,6 +276,7 @@
 								"uxid": "14027340f6e1d98bba3f7f5f3b50e3588f8a19e4d021db944e7a28b2643640e1",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "635750.000000",
+								"src_txid": "a7665cec98224150968ec1ef9ef2d6b3175c9de8f9f8c7bc786b30cc74997c57",
 								"hours": 127440,
 								"calculated_hours": 146865
 							}
@@ -334,6 +340,7 @@
 								"uxid": "04c0cd4cbee1e5414791d9e0b9ae4f889bc52d253b5f70b09fbc32c88fb415ae",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "3.000000",
+								"src_txid": "fa33df7c4316cea05095e6c7ce86f361847893d26fe2255af118593a33686c52",
 								"hours": 4,
 								"calculated_hours": 1748
 							},
@@ -341,6 +348,7 @@
 								"uxid": "f3034ffe54e869315f8e11801d3e755352fb75b878b24313302273c1b7ea62cb",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1.000000",
+								"src_txid": "fa33df7c4316cea05095e6c7ce86f361847893d26fe2255af118593a33686c52",
 								"hours": 0,
 								"calculated_hours": 581
 							},
@@ -348,6 +356,7 @@
 								"uxid": "3538af0016ec0f4d0e943c5d49daf280b416701fde4040fa72710c0ca1b5b559",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1.000000",
+								"src_txid": "b68d78c9a4610b540933eaa550fbb1c473f5cf749eb522882f8154d495453e7d",
 								"hours": 0,
 								"calculated_hours": 581
 							},
@@ -355,6 +364,7 @@
 								"uxid": "0560bae3917bca7581af9b6c5a58e395c701ce9ed0241dac2de8a3e93c0b839b",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "77a69f4c8afd858a2f6767bb9980d4af6520e02b076bf2a78b935021e1147c71",
 								"hours": 1605,
 								"calculated_hours": 510237
 							},
@@ -362,6 +372,7 @@
 								"uxid": "3fe7d61ffa993e00200ce6be7ba347c603032ac3f8c4ace07767e630fe94d76c",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "0cded82aa3ac92d78e23d2d0d7faf93c675fc9a321ad55105f65b6fca444b1e7",
 								"hours": 125696,
 								"calculated_hours": 610213
 							},
@@ -369,6 +380,7 @@
 								"uxid": "2a09e97f7725a35af1357842206875a023252da4ebfce129eaf4cb87119cfd41",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "bd617ec27c2bea642fad8c153178e11ca08456d752249324e3011f27c845f87a",
 								"hours": 2704,
 								"calculated_hours": 487118
 							},
@@ -376,6 +388,7 @@
 								"uxid": "617b584bb9e6b1d80daac915fb3079b22a326777d1515a40e7b7eddf427f4099",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "072f0738f834db0030d777e6ec0e0443627c51cecffcc55e41d43b0b8edd40d1",
 								"hours": 3102,
 								"calculated_hours": 163688
 							},
@@ -383,6 +396,7 @@
 								"uxid": "18293d947aadf89d9e57d18fa01408867a9abe267504edbdabf8c2a57d9a6323",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "030177271beee04f1a0974d0c5042f07c7ca1db1c5d496fbee3c441b1b7c5bee",
 								"hours": 0,
 								"calculated_hours": 112148
 							},
@@ -390,6 +404,7 @@
 								"uxid": "045dc2e76321e37884588093083ce1b21be12f20ba1fa36f2a755b894229e3cf",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "b0d7ff47658b3e32d8457eb62f6df0c7caaf7feadcbf8cc0c713976026f0404c",
 								"hours": 0,
 								"calculated_hours": 73857
 							},
@@ -397,6 +412,7 @@
 								"uxid": "b1e5c694c30326cda3df2e634723999befbcbb141415e9a36bdbf18d7bea9870",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "6336.000000",
+								"src_txid": "d720ca0efb19b964f481724e5d3f932841e9e75a69b998baf4b575cf3298cb87",
 								"hours": 0,
 								"calculated_hours": 340570
 							},
@@ -404,6 +420,7 @@
 								"uxid": "db7a63750db787959a9e0d2d6be9a1ba8bb3d6015bae2353a27ae9eb55b39d22",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "150.000000",
+								"src_txid": "30e66ff45cfb145eb465e2ebdef0bb10005138bc1727c83888785b04d548e85b",
 								"hours": 0,
 								"calculated_hours": 5180
 							},
@@ -411,6 +428,7 @@
 								"uxid": "5954742a6ca4e3e872d12d4a93436451ad52e6d25e5ac28371e308b2d7ce75a3",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "3991a257eee265481e713917a3a9c15756f61175bcfc7acfdbe84158e43fd5e6",
 								"hours": 0,
 								"calculated_hours": 32930
 							},
@@ -418,6 +436,7 @@
 								"uxid": "a35044035cce79cb988c757dcaf5d9a065957c0fbc1a3559d08ed46831504fc2",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "10464.000000",
+								"src_txid": "fb495093f2f4e5c6555c50150ea60c0a6f430e53aa971ebb3e2b5412866a1f06",
 								"hours": 1014129,
 								"calculated_hours": 1124989
 							},
@@ -425,6 +444,7 @@
 								"uxid": "c31c199a54ecbea5e57bf7f5e73d231a09e11713dd0ee70e340e4b0a9c9f9fdc",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "1000.000000",
+								"src_txid": "7abef7e4080bf2cbe9f147d7c9cbe4c950b38f8477d304466c938b937cd379ba",
 								"hours": 141512,
 								"calculated_hours": 152098
 							}
@@ -475,6 +495,7 @@
 								"uxid": "d6735d3ad70dbf553048faf1c529d047ab12282d04e320bd67c915779fc4e3fd",
 								"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 								"coins": "24950.000000",
+								"src_txid": "a17cf54c20ac7ec6e1362acf24c5e5589ed8b49bdba791a87430de160a473913",
 								"hours": 451992,
 								"calculated_hours": 451992
 							}
@@ -525,6 +546,7 @@
 								"uxid": "a5f3c513b5a01dc5e943a5cae91f54b54cde55e984a9480d68d690f40dfb7914",
 								"owner": "v4qF7Ceq276tZpTS3HKsZbDguMAcAGAG1q",
 								"coins": "5.000000",
+								"src_txid": "a17cf54c20ac7ec6e1362acf24c5e5589ed8b49bdba791a87430de160a473913",
 								"hours": 451992,
 								"calculated_hours": 451992
 							}
@@ -569,6 +591,7 @@
 								"uxid": "8e55f10a0615a0737e6906132e09ac08a206971ba4b656f004acc7f4b7889bc8",
 								"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 								"coins": "625750.000000",
+								"src_txid": "9364ed6cfcc289df74dc6bac1993f7ab3441b898cb3f06918198d2476c83dbac",
 								"hours": 18358,
 								"calculated_hours": 44173190
 							}
@@ -619,6 +642,7 @@
 								"uxid": "c39acd3494113650c1a6a7809287af7b12a78bbd97126d4585dd1715e2cb5a66",
 								"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 								"coins": "23100.000000",
+								"src_txid": "ad44a8027a825e82a20cdd910d9bd41d74025601b7668c80655e9b45afb8bb93",
 								"hours": 18586,
 								"calculated_hours": 3020347
 							}

--- a/src/api/integration/testdata/confirmed-and-unconfirmed-transactions-verbose.golden
+++ b/src/api/integration/testdata/confirmed-and-unconfirmed-transactions-verbose.golden
@@ -22,6 +22,7 @@
 					"uxid": "c07593d4329f82da243e4bbd7430e4b10e7b35f9ce0a3718d0e6d25d20b4939b",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "661314.000000",
+					"src_txid": "ec79854fade530d84099d5619864a8e1e8ec9d27a086917a239500cada43c6e8",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -65,6 +66,7 @@
 					"uxid": "bc513a68461d5c401e65a500baf7dfa163735ef63b817bb7b73c4139d5c29d18",
 					"owner": "212mwY3Dmey6vwnWpiph99zzCmopXTqeVEN",
 					"coins": "1000.000000",
+					"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 					"hours": 0,
 					"calculated_hours": 561
 				}
@@ -108,6 +110,7 @@
 					"uxid": "bffea1990d71311b695b2d343b9f09a216b7a8257c1cdcb01b2ab9459e1490e3",
 					"owner": "jtuSERvfzN3kUYekg8LemCQ5kF5g97N8ZL",
 					"coins": "10.000000",
+					"src_txid": "acfb61f7ca39d5dfe33e8ed66f73ab181da0a3206d457bf055dcc4b9731a3ec8",
 					"hours": 70,
 					"calculated_hours": 70
 				}
@@ -145,6 +148,7 @@
 					"uxid": "fe6762d753d626115c8dd3a053b5fb75d6d419a8d0fb1478c5fffc1fe41c5f20",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "615700.000000",
+					"src_txid": "f58f664eea258100126636a4111838e489ef5aec848ca8498319c290fa2a0805",
 					"hours": 5521648,
 					"calculated_hours": 45730107
 				}

--- a/src/api/integration/testdata/empty-addrs-transactions-verbose.golden
+++ b/src/api/integration/testdata/empty-addrs-transactions-verbose.golden
@@ -49,6 +49,7 @@
 					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
+					"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 					"hours": 100000000000000,
 					"calculated_hours": 100000000000000
 				}
@@ -680,6 +681,7 @@
 					"uxid": "e3e72ee077c8b0c3f87da7cf50cad8876bd3f489f373d9fe82fc2e971df56f76",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "1000000.000000",
+					"src_txid": "86564b421cd3d4fe6f5f2d7a3e5db9d6fc340892bddd3a150533dff7036d0efe",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -723,6 +725,7 @@
 					"uxid": "af0b2c1cc882a56b6c0c06e99e7d2731413b988329a2c47a5c2aa8be589b707a",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -760,6 +763,7 @@
 					"uxid": "0cd548e03bd13bca8647cd13f6baef0c65fd03081aeb6dc3695536e5bc6018ae",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999990.000000",
+					"src_txid": "312a269b8248e389c61571cc13f4ad13b7d53b64853d990ddc301a58e7071889",
 					"hours": 1,
 					"calculated_hours": 5556
 				}
@@ -804,6 +808,7 @@
 					"uxid": "9eb7954461ba0256c9054fe38c00c66e60428dccf900a62e74b9fe39310aea13",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10.000000",
+					"src_txid": "a6a709e9388a4d67a47d262b11da5f804eddd9d67acc4a3e450f7a567bdc1619",
 					"hours": 0,
 					"calculated_hours": 2405
 				},
@@ -811,6 +816,7 @@
 					"uxid": "706f82c481906108880d79372ab5c126d32ecc98cf3f7c74cf33f5fda49dcf70",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999980.000000",
+					"src_txid": "c24b92898381fbebe59a457924184f4cce1e7166e140ca75aea5baf854c1ab75",
 					"hours": 3704,
 					"calculated_hours": 3704
 				}
@@ -854,6 +860,7 @@
 					"uxid": "dc63c680f408c4e646037966189383a5d50eda34e666c2a0c75c0c6bf13b71a1",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "100.000000",
+					"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -897,6 +904,7 @@
 					"uxid": "8ff8a647e4542fab01e078ac467b2c9f2e5f7de55d77ec2711f8abc718e2c91b",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "95.000000",
+					"src_txid": "03b3ab821cdaf0ab8cc1a9e2dd30108772ec3bda09e9d3a8c48df9f30d213b38",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -940,6 +948,7 @@
 					"uxid": "17090c40091d009d6a684043d3be2e9cb1dc60a664a9c2e388af1f3a7345724b",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "90.000000",
+					"src_txid": "f832428481690fa918d6d29946e191f2c8c89b2388a906e0c53dceee6070a24b",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -983,6 +992,7 @@
 					"uxid": "999cc56deae71486a28e19d1ed8d585c2cf07d5ee27d1c33bea186d23aaca06a",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "85.000000",
+					"src_txid": "7229422f3a0afb5f3a9596ed50146440c17a3d54abda0f3c70cd9dc58de96374",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1026,6 +1036,7 @@
 					"uxid": "2f87d77c2a7d00b547db1af50e0ba04bafc5b05711e4939e9ec2640a21127dc0",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "80.000000",
+					"src_txid": "9d87d7bb9e56a3588bacb478c7556280b28c0a49f6e09db8b54a84c20d865f2f",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1069,6 +1080,7 @@
 					"uxid": "ec2c2238793d71240502de3e7c46ec1d5bf938c76541185f1c3fdf0d99a90795",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "5.000000",
+					"src_txid": "98db7eb30e13853d3dd93d5d8b4061596d5d288b6f8b92c4d43c46c6599f67fb",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1112,6 +1124,7 @@
 					"uxid": "3f8c01eefca28ec6d89d34b899fecb5c97f9348b412c61e7c863310b8a85b953",
 					"owner": "2M2VC93aQv5asdcNKt7pzJdkxeL6xLw9JPp",
 					"coins": "1.000000",
+					"src_txid": "4a87de6869c974099e3f5522404fbc7b23f90a8f8dec958bf725317454036cdc",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1149,6 +1162,7 @@
 					"uxid": "9c7d3674d7a6b28a559a052e6d354ec13d2e0396739973c9f0dce08f8c7d157c",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "4.000000",
+					"src_txid": "4a87de6869c974099e3f5522404fbc7b23f90a8f8dec958bf725317454036cdc",
 					"hours": 0,
 					"calculated_hours": 6
 				}
@@ -1192,6 +1206,7 @@
 					"uxid": "34de4a6d093e880f813b4dc466b51f6814923e157ffbba0e9abbc4bfbd938de8",
 					"owner": "2AsyTLyWNR3FGhaMbLckaJyAZN46mrqFfXA",
 					"coins": "1.000000",
+					"src_txid": "9ea7b912cbfca157ef5fe9c59dd2407302d1b4d95414829d93c45bde6c2d42c8",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1229,6 +1244,7 @@
 					"uxid": "0c5d1b6a61c32f9bcc62d3583ac957b3374f0daf1a14fd08679bff2554449840",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "75.000000",
+					"src_txid": "98db7eb30e13853d3dd93d5d8b4061596d5d288b6f8b92c4d43c46c6599f67fb",
 					"hours": 0,
 					"calculated_hours": 153
 				}
@@ -1272,6 +1288,7 @@
 					"uxid": "4a06f4b59bc5626e6a92704b4e4441096e909b884eab84505699a3136abb69b3",
 					"owner": "PRXLNyB64cqaiG4pCoFZZ8Tuv7LWYPpa7m",
 					"coins": "5.000000",
+					"src_txid": "70dd5840d7260cf584457c76d3226312f4d033c023caf8c0ab3a65f9b831e9e0",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1315,6 +1332,7 @@
 					"uxid": "fa2b598d233fe434f907f858d5de812eacf50c7b3fd152c77cd6e246fe356a9e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999890.000000",
+					"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 					"hours": 4073,
 					"calculated_hours": 6061184
 				}
@@ -1358,6 +1376,7 @@
 					"uxid": "c603e99ceae4d15c20360714ee07ba6e3a944a97ea9285d164c23252e93958b6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1395,6 +1414,7 @@
 					"uxid": "acd35cec566de86b4ed464b6cf3c3ec561140c070134d1e03094775454da2159",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "70.000000",
+					"src_txid": "70dd5840d7260cf584457c76d3226312f4d033c023caf8c0ab3a65f9b831e9e0",
 					"hours": 102,
 					"calculated_hours": 3402
 				}
@@ -1438,6 +1458,7 @@
 					"uxid": "af7deecc9b45c4696ad50246c8aa06b17aa8280b2574f295697a4210fc45f57d",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "65.000000",
+					"src_txid": "c6eccf17b4b952f19548b1924126c9dc409b45f9e6fcc0954a3494e7399f5fd4",
 					"hours": 2268,
 					"calculated_hours": 2268
 				}
@@ -1481,6 +1502,7 @@
 					"uxid": "ec9bbaf9309772ade9860f145705b9e9ee4a70ed1eeed1983d058ccaafd6c02c",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "60.000000",
+					"src_txid": "22766105d0f93d01fed7bed2dcabedfd89fe846621c912b0af845d8ba5d265f8",
 					"hours": 1512,
 					"calculated_hours": 1512
 				}
@@ -1524,6 +1546,7 @@
 					"uxid": "1f4f952c6304e3991cf33519f1084921d50ecfd845edc48bd3b7b7229e28f2a6",
 					"owner": "Kb9SqqTVA3XyQjZYb4wYrBVUeZWRKEQyzZ",
 					"coins": "5.000000",
+					"src_txid": "67f180076fed1599152c62337a12deee7e1a468b19f7e720df51415c28bfb986",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1567,6 +1590,7 @@
 					"uxid": "4c84a4bf9a1b1a3a53d8bf78e8823ca3135321089968068ac60da32083027846",
 					"owner": "Kb9SqqTVA3XyQjZYb4wYrBVUeZWRKEQyzZ",
 					"coins": "4.000000",
+					"src_txid": "c820bf59805b4889e59ce5fa320dcccfce5180de5f0f8baef7b391049ea8e286",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1611,6 +1635,7 @@
 					"uxid": "182b4c32bb5fe0e6809a19db63eecbeefde97a6c043b9248da94d428ab5a94c2",
 					"owner": "2bvEzLx4mgyQkYL5bkSc2rD9V1nqWBqn8vp",
 					"coins": "1.000000",
+					"src_txid": "c820bf59805b4889e59ce5fa320dcccfce5180de5f0f8baef7b391049ea8e286",
 					"hours": 0,
 					"calculated_hours": 0
 				},
@@ -1618,6 +1643,7 @@
 					"uxid": "20900f1d317e0b10ebab7190a34265f52783ff4f85675398b497ab8eb3723a3c",
 					"owner": "2bvEzLx4mgyQkYL5bkSc2rD9V1nqWBqn8vp",
 					"coins": "1.000000",
+					"src_txid": "eb0a48072c5da37962c07d205a1843311f98e886cfcbdb2813359677f36bebc2",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1655,6 +1681,7 @@
 					"uxid": "f3ce12886e74d6407f9580b47e72156a917083b66ebaa46263c7fde2df35116e",
 					"owner": "Kb9SqqTVA3XyQjZYb4wYrBVUeZWRKEQyzZ",
 					"coins": "3.000000",
+					"src_txid": "eb0a48072c5da37962c07d205a1843311f98e886cfcbdb2813359677f36bebc2",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1699,6 +1726,7 @@
 					"uxid": "4168b9378363cd81939e667cf78055d35a60d3101f5f9e3d2ae709e3981e29fc",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999880.000000",
+					"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 					"hours": 4040790,
 					"calculated_hours": 4543507
 				},
@@ -1706,6 +1734,7 @@
 					"uxid": "d9dae1f82177f979b07016a341ed5c281ed6ed8eaa785a8a107ec16efbe541ef",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10.000000",
+					"src_txid": "686db0a8cd429970bb91163033703410d4750c86ba485709fe1a3faabbbb42f6",
 					"hours": 0,
 					"calculated_hours": 4
 				}
@@ -1749,6 +1778,7 @@
 					"uxid": "8793a3782bf673393a8f909f267f3bfcc713b600460893b571fd55f675ac65ba",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999880.000000",
+					"src_txid": "56e7bd13dc4c6e1cd80aba66a0a9fed650d0646659ac774e3f1b415848755d85",
 					"hours": 567938,
 					"calculated_hours": 567938
 				}
@@ -1792,6 +1822,7 @@
 					"uxid": "778048daec0c83f89525a6d69b60c407d090bb1666711b1c560e6ebee8dcc452",
 					"owner": "bNQHMc2nM8x2fssmyUp6QWY1ow6LzB7kZz",
 					"coins": "5.000000",
+					"src_txid": "03b3ab821cdaf0ab8cc1a9e2dd30108772ec3bda09e9d3a8c48df9f30d213b38",
 					"hours": 0,
 					"calculated_hours": 284
 				}
@@ -1835,6 +1866,7 @@
 					"uxid": "98b3e6e6d4ed36159b7dbf5f305174fc0c255d2d97528b35a67d50b9968e2b2f",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "c24b92898381fbebe59a457924184f4cce1e7166e140ca75aea5baf854c1ab75",
 					"hours": 0,
 					"calculated_hours": 629
 				}
@@ -1872,6 +1904,7 @@
 					"uxid": "92ae7cf57ad1363a60ce019818f7304040959329b6513f9a2d0f6b464bacafea",
 					"owner": "bNQHMc2nM8x2fssmyUp6QWY1ow6LzB7kZz",
 					"coins": "3.000000",
+					"src_txid": "f2f9926afcd29405327ddb772988a73dc13a67b1fcaa42ad98a416060e96adce",
 					"hours": 35,
 					"calculated_hours": 35
 				}
@@ -1909,6 +1942,7 @@
 					"uxid": "18ea1b3cceb2ca40c01efc8f3cfd7d1d0dd69430ecdf655515aa4f8b21bd2644",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "260d249883165aa9e59e17fb2bd8ba8995d2c3644993530985f8b813ed378650",
 					"hours": 78,
 					"calculated_hours": 78
 				}
@@ -1952,6 +1986,7 @@
 					"uxid": "64194899d317e2a007f89df14538795547e927c242a92f83180e6cc952304964",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "5.000000",
+					"src_txid": "9004c779cff67b3895500ec14b2c2e566127bb11a8af3358fe8a63dcfae9badc",
 					"hours": 9,
 					"calculated_hours": 9
 				}
@@ -1990,6 +2025,7 @@
 					"uxid": "569aa1260e734017c4eee06d84ab4a6285e2ca2041940b2915d9141527caf179",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "5.000000",
+					"src_txid": "9004c779cff67b3895500ec14b2c2e566127bb11a8af3358fe8a63dcfae9badc",
 					"hours": 9,
 					"calculated_hours": 9
 				},
@@ -1997,6 +2033,7 @@
 					"uxid": "eb446b8372559249c8e269b6cd028588e2e9e4f8fe9357719da9d1c22aa29911",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "5.000000",
+					"src_txid": "327375203f20cb68847351c30a48597c0588a8c14319a4eb47bf440207fd045a",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -2034,6 +2071,7 @@
 					"uxid": "e702df2703c3de180f3e4a0e9a503bd534037c2d68e858e97a317575c5a97d95",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "e89ee3e90e72108e4cd6ccb95c9f8d2b18ccfaa7ce61a7d297454debd69cebbf",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -2077,6 +2115,7 @@
 					"uxid": "10998e83dc5dfe3c3f5f28ef3e5e2fced4dbd1da389678b0ea3ddb552851b6bf",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "6.000000",
+					"src_txid": "08bf0f8f4a8547bcab1fef035adac2a66c80369b4485a736bdd676e782bbb037",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -2115,6 +2154,7 @@
 					"uxid": "41c6d29aa5de770de684ab19b40bd75b99ec7f1a5ff7d15288ae4bfff568eabd",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "4.000000",
+					"src_txid": "08bf0f8f4a8547bcab1fef035adac2a66c80369b4485a736bdd676e782bbb037",
 					"hours": 0,
 					"calculated_hours": 0
 				},
@@ -2122,6 +2162,7 @@
 					"uxid": "9e5779445f60d62b471862339d7a83dd8355c7a89d5fc3b751f98e9414628ec2",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "6.000000",
+					"src_txid": "3170f0635cc40aded3a38f84f2ae07bd2238550ea4ee867328d0f891ea9abf14",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -2159,6 +2200,7 @@
 					"uxid": "d46e91fea3c8a6428885f941e5152dbc7f9abd356ad4d054bf20e0e806f1ec99",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "fba515a9eeaedb891c4dca862bd06108e0452270890b362f0b353b4c86845618",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -2196,6 +2238,7 @@
 					"uxid": "ad742bbc7420c08881e6ccf35e34e8472c0dd6386792359aedcfb752ca618c33",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999790.000000",
+					"src_txid": "cff53a059d55f2c90f6dd7ce7de2cc07cbdbd50b25867cba0f41cd0192614d0d",
 					"hours": 70992,
 					"calculated_hours": 3113963
 				}
@@ -2239,6 +2282,7 @@
 					"uxid": "108520145179c00f581d91e273714811fe6e82ee059d65218eea91154ebd8205",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "998790.000000",
+					"src_txid": "a76cd63b71f1f5425941cd567627e1dcdc8c34306a7945ea48755f5a46efb6f5",
 					"hours": 389245,
 					"calculated_hours": 389245
 				}
@@ -2282,6 +2326,7 @@
 					"uxid": "e79c94aa7013c7611901839236b8a1cdf70e8ef7c40b9e33f99359136de981d6",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "988790.000000",
+					"src_txid": "c38b47bd576e3bced2a9309c3df7622064e71177f54020d77193d5cac310719c",
 					"hours": 48655,
 					"calculated_hours": 48655
 				}
@@ -2325,6 +2370,7 @@
 					"uxid": "c65a9e6aa33244958e9595e9eceed678f9f17761753bf77000c5474f7696da53",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "978790.000000",
+					"src_txid": "b56f3e9239da5c5f9bb5ca80226b8454ba36ce6012f8e323a50c9d9c4eb4a834",
 					"hours": 6081,
 					"calculated_hours": 6081
 				}
@@ -2369,6 +2415,7 @@
 					"uxid": "f48432d381a10abecbd1357d81705ea922246e92170fe405d1a4a35c5ceef6a4",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "1000.000000",
+					"src_txid": "a76cd63b71f1f5425941cd567627e1dcdc8c34306a7945ea48755f5a46efb6f5",
 					"hours": 389245,
 					"calculated_hours": 389256
 				},
@@ -2376,6 +2423,7 @@
 					"uxid": "6bbf13da052e1baade111ae8bb85548732532c8f5286eba8345d436d315d1c93",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "9000.000000",
+					"src_txid": "cf4fe76a08e3296b6f6abdb949604409be66574f211d9d14fde39103c4cfe1d6",
 					"hours": 760,
 					"calculated_hours": 760
 				}
@@ -2421,6 +2469,7 @@
 					"uxid": "e3e95cd390c42d2f08e2c173135620e09c7a2ec1cf80ff75fbc3940fa5712b3c",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "55.000000",
+					"src_txid": "67f180076fed1599152c62337a12deee7e1a468b19f7e720df51415c28bfb986",
 					"hours": 1008,
 					"calculated_hours": 2035
 				},
@@ -2428,6 +2477,7 @@
 					"uxid": "7f44d7ef014419278137cbaa344cb550fc3c07355ec619d917bea3bc15fb8817",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "2.000000",
+					"src_txid": "f2f9926afcd29405327ddb772988a73dc13a67b1fcaa42ad98a416060e96adce",
 					"hours": 35,
 					"calculated_hours": 56
 				},
@@ -2435,6 +2485,7 @@
 					"uxid": "61c61dfe5b82fde557a698b402c82ac0205929478e705cbadec7f5d47a51d403",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "3.000000",
+					"src_txid": "044a75b1d3d273cae560ca43f9351d9acde206b0ad5578eb3adc2598886b5134",
 					"hours": 4,
 					"calculated_hours": 35
 				}
@@ -2478,6 +2529,7 @@
 					"uxid": "88162721a552b1422546024772fc822faa187e897754e0a579e5e4a92a7cf4c9",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "55.000000",
+					"src_txid": "d368fc3112b522c52a5b191981ca52678cc7db29bdc3493cf551be88d109ef9c",
 					"hours": 265,
 					"calculated_hours": 265
 				}
@@ -2521,6 +2573,7 @@
 					"uxid": "195f5e50b4eed1ec7ff968feca90356285437adc8ccfcf6623b55a4eebf7bbb5",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "969790.000000",
+					"src_txid": "cf4fe76a08e3296b6f6abdb949604409be66574f211d9d14fde39103c4cfe1d6",
 					"hours": 760,
 					"calculated_hours": 3203760
 				}
@@ -2564,6 +2617,7 @@
 					"uxid": "cb8efc0b1082c39258cb6efd59f64d88b36fcb60143c826829fc5f0ed5c0d668",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944790.000000",
+					"src_txid": "df622e8c9dfaed1d7dca83ad7f6d8946bb86b81398bad521d858cbefef8e4688",
 					"hours": 400470,
 					"calculated_hours": 400470
 				}
@@ -2607,6 +2661,7 @@
 					"uxid": "a6061defc41a8a55e37eaf56ebaa1177446f61719b1d5126698e79a6023f5367",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944780.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50058
 				}
@@ -2650,6 +2705,7 @@
 					"uxid": "3b5f72e772ea886dd872b9087395398133576a6561072d5294fbcd04b49e1d95",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944770.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6257
 				}
@@ -2693,6 +2749,7 @@
 					"uxid": "f265bea876ffcfb8cf64df3aca4dae4a8d7f424ff495d91fb322feddb3a7e505",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944760.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 782
 				}
@@ -2736,6 +2793,7 @@
 					"uxid": "19efa2bd8c59623a092612c511fb66333e2049a57d546269c19255852056fead",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "9000.000000",
+					"src_txid": "0e91a08561e85a36ddf44e77b9228f7d561c18c0b46d19083d4af511085b697e",
 					"hours": 48752,
 					"calculated_hours": 95777
 				}
@@ -2779,6 +2837,7 @@
 					"uxid": "f8ad5c72e7822c7ac9a1dce8de583e34f6f830052bc0a02d749e9e81790dae86",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "10000.000000",
+					"src_txid": "b56f3e9239da5c5f9bb5ca80226b8454ba36ce6012f8e323a50c9d9c4eb4a834",
 					"hours": 6081,
 					"calculated_hours": 58747
 				}
@@ -2822,6 +2881,7 @@
 					"uxid": "5fa90c22a26ecec8c03696a018b590a5e1679efa9cb5e8263facf9bcc6628db6",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "8000.000000",
+					"src_txid": "be27621ad46680b343cc1406f5c6a1717704ce169e988ed7afb586f8112ae6f0",
 					"hours": 11972,
 					"calculated_hours": 11994
 				}
@@ -2865,6 +2925,7 @@
 					"uxid": "e6d9b56e075a6adf520d1ae7fbab9ae06353ae0b93dc8cb17d82cc3628009a50",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944750.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 23715
 				}
@@ -2908,6 +2969,7 @@
 					"uxid": "e4fa8fe06d04bb438323f295eea23535856be08b369be71a2ce3e9e7bc0b1e09",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "7000.000000",
+					"src_txid": "231254039042675300dbdd61a6ca54941214e383b5f6380323f848482b4f4628",
 					"hours": 1499,
 					"calculated_hours": 1537
 				}
@@ -2951,6 +3013,7 @@
 					"uxid": "f37efd851f76854852fdb8b8ba9afa2c5b7859315cc1fd12c12bf6831c59beb2",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "9000.000000",
+					"src_txid": "814694a8e32f1c81b627f8eb704622c8893d197bf32bbd7e1bf73bec9a831d7d",
 					"hours": 7343,
 					"calculated_hours": 7443
 				}
@@ -2994,6 +3057,7 @@
 					"uxid": "df5d6e09da2585a6ac1a37aea2370fa25e9049b549049202d5417138bf033cfa",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "10000.000000",
+					"src_txid": "c38b47bd576e3bced2a9309c3df7622064e71177f54020d77193d5cac310719c",
 					"hours": 48655,
 					"calculated_hours": 101571
 				}
@@ -3037,6 +3101,7 @@
 					"uxid": "2df1e88589be43c55d7c6c3dbcbd663fb759b3245eb8d86b0b9cdaa989556aea",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "943750.000000",
+					"src_txid": "d154d8262abbf517c67d529b0fea7cdf097433bd296d5795b17c6379cb1b1430",
 					"hours": 2964,
 					"calculated_hours": 13450
 				}
@@ -3080,6 +3145,7 @@
 					"uxid": "f5beae016bda8260218fc05468c300fa71ddd46f4c6337fffac8d83229461f5f",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "6000.000000",
+					"src_txid": "88d239f2584c78b73a1905fd0dcce3beabfdfc5a9c54518862b009e22e972c68",
 					"hours": 192,
 					"calculated_hours": 292
 				}
@@ -3123,6 +3189,7 @@
 					"uxid": "298fabb8217a2b0322f104b0cb295383bfdbc599d6a81e07610e0922eb99f89a",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "8000.000000",
+					"src_txid": "374f01de8274656147be0a23ccc5677773da6f32b071ee796bda0851b6dcd2ac",
 					"hours": 930,
 					"calculated_hours": 1063
 				}
@@ -3166,6 +3233,7 @@
 					"uxid": "3d7dd4d41e613fe8153f5e5f62b79494e9db9ed98f875d929ca1f90ecfe2d50b",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "9000.000000",
+					"src_txid": "8fba29db2e3e8cad785e723f95aa5fa46ae0dd8b2bb62586977f20e698642cfb",
 					"hours": 12696,
 					"calculated_hours": 12846
 				}
@@ -3209,6 +3277,7 @@
 					"uxid": "c5150380691c542b9bdf4cf2280ac612e0576c349f99d47d0a03c77eedc48731",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "942750.000000",
+					"src_txid": "61a33b49e97bfe2d5f026bf45fae43a1b9bdf08c60ec8db017da720a69790c7f",
 					"hours": 1681,
 					"calculated_hours": 12156
 				}
@@ -3252,6 +3321,7 @@
 					"uxid": "53ea8733d94ae54bade0b55df03a03b3c0f6e6683b9260c36b14e3fc311d6f49",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "5000.000000",
+					"src_txid": "5d1cb86b48c8834c8c12fc36a83259609300f2f6a148faa1492a473cee21bc02",
 					"hours": 36,
 					"calculated_hours": 105
 				}
@@ -3295,6 +3365,7 @@
 					"uxid": "77769e6a01cf3dca201ade501767d0abf20dea19d694f3272b647a9a651fdee9",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "8000.000000",
+					"src_txid": "77a69f4c8afd858a2f6767bb9980d4af6520e02b076bf2a78b935021e1147c71",
 					"hours": 1605,
 					"calculated_hours": 1693
 				}
@@ -3338,6 +3409,7 @@
 					"uxid": "9bbb8d620aae3efc7c21bb7d6a7159eda441a83e0fef2cd98f8240b38857d648",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "941750.000000",
+					"src_txid": "4aeafd20b9df56ec852a2c257ff1630b9530d8375a4e72f20238ea36835f76d5",
 					"hours": 1519,
 					"calculated_hours": 9366
 				}
@@ -3381,6 +3453,7 @@
 					"uxid": "83b5fa4051dbfd50ba903374e5e583a9345c6a980505ee56963de9bd8e539e36",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "4000.000000",
+					"src_txid": "057ae2bee6e1fc2c9997d48aab3e348a7f17ad0305d6e6a14f4f663404b4a00a",
 					"hours": 13,
 					"calculated_hours": 46
 				}
@@ -3424,6 +3497,7 @@
 					"uxid": "1efc8693845733061e1407a74e86976a52a69c63a14d6a79e1f3e45277662900",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "7000.000000",
+					"src_txid": "4ce860140dbb5f90f39086b0c51323005145a95b365204bd33e3d90fbdc35f51",
 					"hours": 132,
 					"calculated_hours": 345
 				}
@@ -3467,6 +3541,7 @@
 					"uxid": "25ad0d5ae6a1a9bc61c6b9099fb7829111977a59e1183de4227a0a5352555639",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "940750.000000",
+					"src_txid": "29c229c97d27bcaf842a367520e1916fb855921906bddf4a3b0413ad3f11517b",
 					"hours": 1170,
 					"calculated_hours": 11622
 				}
@@ -3510,6 +3585,7 @@
 					"uxid": "acc75d51ff9f18a224d1ca0481917e2a67298de40955711cd97a08f6733b5b6a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "939750.000000",
+					"src_txid": "42227683dd9c149859d0578ab300d8509d513afadf7834fd8ae7a321cc07d833",
 					"hours": 1452,
 					"calculated_hours": 1452
 				}
@@ -3553,6 +3629,7 @@
 					"uxid": "5c1069a3aa6628ed7f9bdb300bec1a7e7ca6fb4645528a8c6a27c167e7dfe698",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "938750.000000",
+					"src_txid": "d803ab903f68f7861cd8eff93b3c097c5b8f6a697ca67bb01e7e645060839fd0",
 					"hours": 181,
 					"calculated_hours": 181
 				}
@@ -3596,6 +3673,7 @@
 					"uxid": "8190fd31c005510d550c8a241b127fad2558c82aed9483fb4423193d5f4429e3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "913750.000000",
+					"src_txid": "3bf485890e91268452dc3136c0b294dc9909b3aaa10b9c936743e6e9b1a56f61",
 					"hours": 22,
 					"calculated_hours": 22
 				}
@@ -3639,6 +3717,7 @@
 					"uxid": "450cd7795bb3625daa99d6b64b9a8786d593bf1cad986d6c2933dae04b74a593",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "888750.000000",
+					"src_txid": "f51e2ce31961b0186e04cc9d78857c3c21d3e2afb25c050d8c1d67d3320fcc07",
 					"hours": 2,
 					"calculated_hours": 2
 				}
@@ -3684,6 +3763,7 @@
 					"uxid": "3fe6b13824f28d69588c309278420069bc0efae95367d0d6f93cb40af15eeaa6",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "6000.000000",
+					"src_txid": "bbd1d4b6fe89a5986efbea9f7996cca2a515c3f0788cedccc21990dc78d83509",
 					"hours": 43,
 					"calculated_hours": 443
 				},
@@ -3691,6 +3771,7 @@
 					"uxid": "5a7b2b6568cfa4ff5d44e98446aed92438ede0103b9994cfa3389bd02a35239b",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "25000.000000",
+					"src_txid": "3bf485890e91268452dc3136c0b294dc9909b3aaa10b9c936743e6e9b1a56f61",
 					"hours": 22,
 					"calculated_hours": 230
 				},
@@ -3698,6 +3779,7 @@
 					"uxid": "9639a86df8da288fb0fc6a92fa086f3cd5a8387705a14ddd2aa5e30c6c3fc3fb",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "25000.000000",
+					"src_txid": "f51e2ce31961b0186e04cc9d78857c3c21d3e2afb25c050d8c1d67d3320fcc07",
 					"hours": 2,
 					"calculated_hours": 71
 				}
@@ -3741,6 +3823,7 @@
 					"uxid": "c7919b892eeb751456d456b37ccde7350a3fca0dda03b17ec426a56f12dcf192",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "1000.000000",
+					"src_txid": "d154d8262abbf517c67d529b0fea7cdf097433bd296d5795b17c6379cb1b1430",
 					"hours": 2964,
 					"calculated_hours": 3100
 				}
@@ -3785,6 +3868,7 @@
 					"uxid": "9953e00abe05db134510693a44b8928ca9b29d0009b38d9c4f8dcdedee7edc35",
 					"owner": "4EHiTjCsxQmt4wRy5yJxBMcxsM5yGqtuqu",
 					"coins": "1000.000000",
+					"src_txid": "0e91a08561e85a36ddf44e77b9228f7d561c18c0b46d19083d4af511085b697e",
 					"hours": 48752,
 					"calculated_hours": 57799
 				},
@@ -3792,6 +3876,7 @@
 					"uxid": "8f52e126bbc359bc3bfd230d82649c3d1c622e8f9c20dae7ccd73bd0b4ee2bad",
 					"owner": "4EHiTjCsxQmt4wRy5yJxBMcxsM5yGqtuqu",
 					"coins": "5.000000",
+					"src_txid": "a95317361364e8cc08a150840bac8a97ea1f56278f8834ca2a2f16c24c4a7f0f",
 					"hours": 387,
 					"calculated_hours": 387
 				}
@@ -3835,6 +3920,7 @@
 					"uxid": "e2807345a3e76b7050038a9ec40d5a62bd4dcc6b1ed79f186213a32caf7008a1",
 					"owner": "j6pa8kdKqHbxRm2VXJVbzigQDFzqTVfvfq",
 					"coins": "50.000000",
+					"src_txid": "edca397ceedb5fb4462b0aff8fe7f9da5091a4e68f11a34c79daf2c5ae7dd748",
 					"hours": 7273,
 					"calculated_hours": 7273
 				}
@@ -3879,6 +3965,7 @@
 					"uxid": "73ad63090201c13e6fb55d2e51ec5606fe49a40640bea995e347e7389fcea6c6",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "50.000000",
+					"src_txid": "ced30c4ac3107997efa90faa40c8baed47dafc8ddb4feae3ba21275401c36280",
 					"hours": 33,
 					"calculated_hours": 393
 				},
@@ -3886,6 +3973,7 @@
 					"uxid": "4aca4c715985da352bd9aa84787868dac4f4e305c420fe79e6f05acee3bba14a",
 					"owner": "2fGC7kwAM9yZyEF1QqBqp8uo9RUsF6ENGJF",
 					"coins": "25000.000000",
+					"src_txid": "df622e8c9dfaed1d7dca83ad7f6d8946bb86b81398bad521d858cbefef8e4688",
 					"hours": 400470,
 					"calculated_hours": 575956
 				}
@@ -3929,6 +4017,7 @@
 					"uxid": "b44ee00208690c2123989f40edaff0224825afb20ca0952fbd90bddfd3213642",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "863750.000000",
+					"src_txid": "abed13c2a552633d26b5b51c3ac5abf9808756c0203869ed185a7cd673702ba2",
 					"hours": 0,
 					"calculated_hours": 7814538
 				}
@@ -3973,6 +4062,7 @@
 					"uxid": "70dfcdd1a8a321ffd22c4ce313763464f78c2f85a97bb369ac8b82f76d2ea961",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "3000.000000",
+					"src_txid": "e3b7236ad4b209d664ee1e2549f2a0d34a3ba58b12ee46f98fba73c01574e484",
 					"hours": 5,
 					"calculated_hours": 58468
 				},
@@ -3980,6 +4070,7 @@
 					"uxid": "a96ca17d6af858af8c6f24f607a742ae2979ab8f660b8363b7fbe18625c8a048",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "25000.000000",
+					"src_txid": "3872797c8f9964e6ad19552b9b88d2af07be32866bdb9b9c60aa7086f253af43",
 					"hours": 93,
 					"calculated_hours": 485343
 				}
@@ -4024,6 +4115,7 @@
 					"uxid": "f5867b05823c81fc53de36b140415b3b98e4f4cec5883512f8553f70c550d8e7",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "7000.000000",
+					"src_txid": "8d10b0ba11d9dd63d3a3522bc35bd260e8da9109298aa488355ea7201eb961b7",
 					"hours": 211,
 					"calculated_hours": 136742
 				},
@@ -4031,6 +4123,7 @@
 					"uxid": "22edb5931e1c54382f18e41ef774931efb08c278209a1fe8a34100147b707220",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "25000.000000",
+					"src_txid": "abed13c2a552633d26b5b51c3ac5abf9808756c0203869ed185a7cd673702ba2",
 					"hours": 0,
 					"calculated_hours": 485597
 				}
@@ -4074,6 +4167,7 @@
 					"uxid": "dbe677fec72761ed99467a4d45871aafe173d7dc133e8db0346e3f262ae2598a",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "27000.000000",
+					"src_txid": "c1fb9372439d7f43d17809afc2d1bc9b2aa81fa9fccc1d837c79e649ec4843db",
 					"hours": 67976,
 					"calculated_hours": 68351
 				}
@@ -4117,6 +4211,7 @@
 					"uxid": "6060c983054614b8801e405de697c443a1edebd3236582f89f01c6cf6a165c3f",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "862750.000000",
+					"src_txid": "29798149e90f6442489bcc3294f455441a5a401e81491ed06bdc2c850756f0d9",
 					"hours": 976817,
 					"calculated_hours": 1005575
 				}
@@ -4160,6 +4255,7 @@
 					"uxid": "3a7e60306a5fc882d0c4edcb2990d14be6b80dad1a41b06f8ae5e0308078bafa",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "31000.000000",
+					"src_txid": "3872797c8f9964e6ad19552b9b88d2af07be32866bdb9b9c60aa7086f253af43",
 					"hours": 93,
 					"calculated_hours": 744403
 				}
@@ -4203,6 +4299,7 @@
 					"uxid": "09661724179523e8aec95862a5fd12dd1aa50f39f193f81eece0d7aea6197103",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "31000.000000",
+					"src_txid": "2558a7cd524acdb58f822a56bd51e8905182b2b35fbfdb1246ce6dc9930d14eb",
 					"hours": 77792,
 					"calculated_hours": 219961
 				}
@@ -4246,6 +4343,7 @@
 					"uxid": "6a8bc7ef9e8e7b67fd270cf37022edadb13f1fc2ba4e7a026f7ce2ab30cc4572",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "30000.000000",
+					"src_txid": "d80d49958166fd7b35cee63cfc4a4fdd434484f9bfd9444f62a1b856da36e9c7",
 					"hours": 27495,
 					"calculated_hours": 27495
 				}
@@ -4289,6 +4387,7 @@
 					"uxid": "129726406b3101d51ffd5bfca59a501184d6c8ca363be4ef1b8d8bf48a6c70e0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "861750.000000",
+					"src_txid": "0cded82aa3ac92d78e23d2d0d7faf93c675fc9a321ad55105f65b6fca444b1e7",
 					"hours": 125696,
 					"calculated_hours": 161602
 				}
@@ -4332,6 +4431,7 @@
 					"uxid": "05f42f22f5fea4b5cac8182dc2b4f280149c686434c6d4195a119a8d02ab24b2",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "861050.000000",
+					"src_txid": "b7b42b1b29acab0a2328aaf368ec74be49b4d4caf827e82b439ef4d8be976a55",
 					"hours": 20200,
 					"calculated_hours": 20200
 				}
@@ -4375,6 +4475,7 @@
 					"uxid": "fa761f3b902ced1ad8e94231af3447315a8c8bcdbbdcfcd69bb74ca5ae66f6e9",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "26000.000000",
+					"src_txid": "5db4378f5abcbb48774fc3731a164fb7bbdccf410c3ff829c5706e4d9ef1b1c6",
 					"hours": 8543,
 					"calculated_hours": 129298
 				}
@@ -4418,6 +4519,7 @@
 					"uxid": "dc8162cf85ce1a434adebab2d13abffb587c0e50b86fd1a997bca67f07a66ebd",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "30000.000000",
+					"src_txid": "0ad2691de38a15ec31b0fbe9a0c1175138c9d7b7558db2f016a23619f3dbbc6d",
 					"hours": 93050,
 					"calculated_hours": 95300
 				}
@@ -4461,6 +4563,7 @@
 					"uxid": "15700b88043b3c08a46c3c4e36e7f431291a26aef1ef26c44ee413feee14b950",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "29700.000000",
+					"src_txid": "8374d85130bbcf496bff138cd040f91fa362eb1b6b6a1c7c9285523437d5589c",
 					"hours": 3436,
 					"calculated_hours": 5086
 				}
@@ -4504,6 +4607,7 @@
 					"uxid": "4e1a98a72639efa6253a7cbea0f3b499fa24fb88612ad81414d20e46d2b5784e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "860050.000000",
+					"src_txid": "ca51f9d0a19bf326d6dd39a1e4dd240adaaae279411093d4a5b20f54cddabb95",
 					"hours": 2525,
 					"calculated_hours": 21637
 				}
@@ -4547,6 +4651,7 @@
 					"uxid": "a68c6c646b6bd42f509a82d0218c8ee648b4a40da20eb0599449a7249b10fee9",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "25000.000000",
+					"src_txid": "cf5a1fad27f8f874f67d3162ae6347154c980ebd97c668d610280418f0f53ce7",
 					"hours": 16162,
 					"calculated_hours": 16717
 				}
@@ -4590,6 +4695,7 @@
 					"uxid": "b187246f68a768f65663b8a208ab107a9bc24af6a062acf3ad41aeb899315a49",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "29000.000000",
+					"src_txid": "efc98a4f94ffda2f1d6575048d75728f228a0bef0467c331f085a0f41f97ae45",
 					"hours": 11912,
 					"calculated_hours": 12234
 				}
@@ -4633,6 +4739,7 @@
 					"uxid": "24c49699aab32caf9456a6b4dacd4d820c853c7639e5500b3be6326660312917",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "28700.000000",
+					"src_txid": "a0956843d442bd4b592d0c1323d153c3c1b2d7d52a86629444de6d1d1b6a4c33",
 					"hours": 635,
 					"calculated_hours": 1033
 				}
@@ -4676,6 +4783,7 @@
 					"uxid": "33e0c4c9536afffd491fef6294f22ffb0d16902493946a051db0b218728a1c44",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "859050.000000",
+					"src_txid": "bd617ec27c2bea642fad8c153178e11ca08456d752249324e3011f27c845f87a",
 					"hours": 2704,
 					"calculated_hours": 14635
 				}
@@ -4719,6 +4827,7 @@
 					"uxid": "d45d0597c7d41fdc69ed09a139925327142589f1e4fb877285fa63c6fa126d38",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "24000.000000",
+					"src_txid": "98baeb9799902593d0f61ee22947089a798c6adafd05dc6a5ea918d982a19857",
 					"hours": 2089,
 					"calculated_hours": 2355
 				}
@@ -4762,6 +4871,7 @@
 					"uxid": "74f7dcc6e516634b5d5722d8664ffabaca3b708a53497bb420ced7c300c39806",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "28000.000000",
+					"src_txid": "54e65c445d0af9dda82085ca4bfe0f326ae54ea2a03bd37e07f81d937de97777",
 					"hours": 1529,
 					"calculated_hours": 1762
 				}
@@ -4805,6 +4915,7 @@
 					"uxid": "fb4d5dcc1c3ac97444e96aa7da392b0d7faf7b7373504c70e497228a4695a7f1",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "27700.000000",
+					"src_txid": "e2d9da9342b21659da0a679536f9d6f533a4ce7dc33a7f768c3441ca3640458d",
 					"hours": 129,
 					"calculated_hours": 436
 				}
@@ -4848,6 +4959,7 @@
 					"uxid": "f32f03f28eece9ddcdc488a85100c94a7c924c185ae560363518dae5e2aacccb",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "858050.000000",
+					"src_txid": "0f4958d590ed4ac9aca79d848731b358b1c01fab9717775cf6515f2bf2706dc8",
 					"hours": 1829,
 					"calculated_hours": 94784
 				}
@@ -4895,6 +5007,7 @@
 					"uxid": "2987e7c89d353ad5d63cea2bf2724dc5f7a5ef5fb81f5ea160a307f0726ac2f5",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "9fb039cd90a4e9b85669bd6ef878b98a9e84eec7d4804e2bff6f0dc9c2739c44",
 					"hours": 0,
 					"calculated_hours": 701
 				},
@@ -4902,6 +5015,7 @@
 					"uxid": "a52408daa8ce7026c70b61d4df4212fb577462060f340bfce779225b3e18193d",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50605
 				},
@@ -4909,6 +5023,7 @@
 					"uxid": "dc73aac74348dd285a1456c1fae2204d7c2039d50a765bdaae0c31f7c7e059db",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6804
 				},
@@ -4916,6 +5031,7 @@
 					"uxid": "e4e375b9dc55ff53d6de9120f1a87ff00e00a779835f8320f2c6b3090d0466e6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 1329
 				},
@@ -4923,6 +5039,7 @@
 					"uxid": "d11b05345917d171f60c31bd2634041b73b97eae364724369ddb8d53369397fb",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 644
 				}
@@ -4960,6 +5077,7 @@
 					"uxid": "aee4af7e06c24bccc2f87b16d0708bfea68ac1b420f97914965f4a23ad9e11d6",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "23000.000000",
+					"src_txid": "c93f8bb30e75ffbc0075a4baf57a0f536e4a9123395b13ce67af5cd2dd0f8cd4",
 					"hours": 294,
 					"calculated_hours": 701385
 				}
@@ -4997,6 +5115,7 @@
 					"uxid": "6002f3afc7054c0e1161bcf2b4c1d4d1009440751bc1fe806e0eae33291399f4",
 					"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 					"coins": "27000.000000",
+					"src_txid": "0301358c2db5314ca43c442bac3c1daf31f4b39f9ac9e22dc157687212cab703",
 					"hours": 220,
 					"calculated_hours": 823240
 				}
@@ -5034,6 +5153,7 @@
 					"uxid": "4e75b4bced3404590d38ca06440c275d7fd86618a84966a0a1053fb18164e898",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26700.000000",
+					"src_txid": "a689a3589730a351f880176b2c15b395967b38a90950e0491e7a1e5531f020a9",
 					"hours": 54,
 					"calculated_hours": 811481
 				}
@@ -5071,6 +5191,7 @@
 					"uxid": "0a5603a1a5aeda575aa498cdaec5a4c893a28669dba84163eba2e90db3d9f39d",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26700.000000",
+					"src_txid": "7b13cab45b52dd2df291ec97cf000bf6ea1b647d6fdf0261a7527578d8b71b9d",
 					"hours": 101435,
 					"calculated_hours": 101435
 				}
@@ -5114,6 +5235,7 @@
 					"uxid": "194cc596d2beda803d8142ddc455872082f84b09a5edd8085082b60d314c1e29",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "23000.000000",
+					"src_txid": "9f20b52befed2cbaaa4a066de7119b7fdbff09a83d8e2a82628671f51f3f6551",
 					"hours": 87673,
 					"calculated_hours": 109842
 				}
@@ -5157,6 +5279,7 @@
 					"uxid": "1e30e9dfe00e055404063e52a4154a72492b13de6acf4871ec5ea6d7c0fcc968",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26600.000000",
+					"src_txid": "9150311508851ca989efb5f82b5a7201724514b6b9f84ec1620c18673462126b",
 					"hours": 12679,
 					"calculated_hours": 14895
 				}
@@ -5203,6 +5326,7 @@
 					"uxid": "99b4e51e1afd04813656e6202c7e462d88ce87ba980da7a62591190d72d1073c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "858000.000000",
+					"src_txid": "fe01250cfdf84eb0182c033c216891e7e6971cc85976c4c46d9e3c608974d233",
 					"hours": 11848,
 					"calculated_hours": 962798
 				},
@@ -5210,6 +5334,7 @@
 					"uxid": "f12164a6ea6ce65ff2ca1f2be7251bece8f7c5747ba8ec68e1ec3b27d45d7b9c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "50.000000",
+					"src_txid": "fe01250cfdf84eb0182c033c216891e7e6971cc85976c4c46d9e3c608974d233",
 					"hours": 11848,
 					"calculated_hours": 11903
 				},
@@ -5217,6 +5342,7 @@
 					"uxid": "427462efeb07a6803f013c789ea43d93240f74f886bf9afd63dc1936a7574a37",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "50.000000",
+					"src_txid": "819106dc50373e5293a7e79f179693e85536e8206d82272930ec08410d92402a",
 					"hours": 7510,
 					"calculated_hours": 7564
 				},
@@ -5224,6 +5350,7 @@
 					"uxid": "f9bffdcbe252acb1c3a8a1e8c99829342ba1963860d5692eebaeb9bcfbcaf274",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "27000.000000",
+					"src_txid": "e8fe5290afba3933389fd5860dca2cbcc81821028be9c65d0bb7cf4e8d2c4c18",
 					"hours": 102905,
 					"calculated_hours": 132080
 				}
@@ -5267,6 +5394,7 @@
 					"uxid": "dfd2834342f3a7caf183472c17801aafacd1775378eb843509d17ad858456cb0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "885000.000000",
+					"src_txid": "8de17dff34a8798f2ac89584f5c559e3bb82c280a3f6890386b4dbc5fef0e8cf",
 					"hours": 139293,
 					"calculated_hours": 139293
 				}
@@ -5310,6 +5438,7 @@
 					"uxid": "aa1133a42417332af8b58e71cc14a651e2731563eaea35f0feacc1e97fac6eef",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "22900.000000",
+					"src_txid": "44d56cfa9f83d874ee10fb32f0d40458f6bf3e86528592c9a9abf3c960fcb278",
 					"hours": 13730,
 					"calculated_hours": 27660
 				}
@@ -5353,6 +5482,7 @@
 					"uxid": "8ac39d41ec014ca6625e5f17e1fbe62db7a4ac154e0e42a017efa037935ae968",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "884900.000000",
+					"src_txid": "6546dfbe6e61e81f3e9f6c9afdfee1c07758f2e486d731ae4d19b40602367656",
 					"hours": 17411,
 					"calculated_hours": 56739
 				}
@@ -5396,6 +5526,7 @@
 					"uxid": "4326c936322df6d59b3b539ea340eb9630c7f8484eba2aeba1a0ed4d431ab614",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "22800.000000",
+					"src_txid": "a8d6420d4f64fad1b698bd77cae5a92aa125f806fb184389edcc278e5cb460fa",
 					"hours": 3457,
 					"calculated_hours": 142790
 				}
@@ -5439,6 +5570,7 @@
 					"uxid": "f9bf35f993452b3d490668bb579fd272da969a1bcca8de0c25000ee57b5d7f54",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "22700.000000",
+					"src_txid": "552a4b194478325ee9f3e4a8648d94bc8eb26432be6fecc881bf71ff9ca15356",
 					"hours": 17848,
 					"calculated_hours": 17848
 				}
@@ -5483,6 +5615,7 @@
 					"uxid": "bae0e928b795e2a80c88161afcbc102dcad6644386f6f44050dde8d586750140",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "881900.000000",
+					"src_txid": "a4c15ae4743246709ec335d33c289576c8893e71f5c3dcee1db6e43eec9242ee",
 					"hours": 7092,
 					"calculated_hours": 11108253
 				},
@@ -5490,6 +5623,7 @@
 					"uxid": "94889dbe1c20eb942b7932c5301737537ac33abd9c81d72e1642ddc70ce320e0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "10000.000000",
+					"src_txid": "6ce27da2ddbc15f03330960b4201dbb3a066ad2e9bbd5366a9564f6befdcae2e",
 					"hours": 2231,
 					"calculated_hours": 2231
 				}
@@ -5533,6 +5667,7 @@
 					"uxid": "1d4595b9fa1c6c3d64f48b6ae5f8f861b1c08a022cbcb04b279df448da3db660",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873900.000000",
+					"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 					"hours": 1388810,
 					"calculated_hours": 1388810
 				}
@@ -5576,6 +5711,7 @@
 					"uxid": "412eff3eef889c682da8db3608fce37d1c5ee2cc297bc88d901648e6ccd418f9",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873800.000000",
+					"src_txid": "1f27afc41896d2c7fdbd2620e606440ad12557e9a4bdd6808dcc2c23d4e32978",
 					"hours": 173601,
 					"calculated_hours": 173601
 				}
@@ -5619,6 +5755,7 @@
 					"uxid": "6ad7993fb2728c2c53ac2c8395a6c62d03c5ef9298ca467e7998fb64fd0c90b4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873700.000000",
+					"src_txid": "e8765b4e6fbca87144df59a6f66815b175e81999509504b117636edc34cbe2af",
 					"hours": 21700,
 					"calculated_hours": 21700
 				}
@@ -5662,6 +5799,7 @@
 					"uxid": "2426f768e00345b641f5b4b4b058c308d528e22437bc6e552f0a9d5bd665e14a",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26500.000000",
+					"src_txid": "41ec724bd40c852096379d1ae57d3f27606877fa95ac9c082fbf63900e6c5cb5",
 					"hours": 1861,
 					"calculated_hours": 518287
 				}
@@ -5705,6 +5843,7 @@
 					"uxid": "0976005ab4540e8211cd929f19634bfaa2f5d8e24177ddb5b803b447ea91f8c3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873600.000000",
+					"src_txid": "bb700553c3e1a32346912ab311fa38793d929f311daeee0b167fa81c1369717e",
 					"hours": 2712,
 					"calculated_hours": 167725
 				}
@@ -5749,6 +5888,7 @@
 					"uxid": "7b132c07322babefa83ab64971b7bfb29bf2cb9ffe9c42dc7e2975a185dcd8b8",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "995.000000",
+					"src_txid": "a95317361364e8cc08a150840bac8a97ea1f56278f8834ca2a2f16c24c4a7f0f",
 					"hours": 387,
 					"calculated_hours": 72454
 				},
@@ -5756,6 +5896,7 @@
 					"uxid": "c961ba554ae30b0edcdf71e834ab2b26d7dff5bcf5955d4874cdba89170392bf",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "100.000000",
+					"src_txid": "1f27afc41896d2c7fdbd2620e606440ad12557e9a4bdd6808dcc2c23d4e32978",
 					"hours": 173601,
 					"calculated_hours": 173704
 				}
@@ -5799,6 +5940,7 @@
 					"uxid": "ba0a94662846565969d361b1b7c248847a48e69f2b9eefb4ffb0bc2efc56a8fd",
 					"owner": "38cVLswijqC2ANV5HxTroeapQzqeoBR88C",
 					"coins": "50.000000",
+					"src_txid": "a83e09e976b038d86491d8c029aec84a6313dc33e692da6ce50a2858e50c4666",
 					"hours": 30769,
 					"calculated_hours": 30769
 				}
@@ -5842,6 +5984,7 @@
 					"uxid": "f480c6097568036b90a2e019f9ee68c0812b2da8828be33a005a7427caf14a2b",
 					"owner": "f38daJDg8rpwL5xWgMY78fBHncQ1N5gQZ7",
 					"coins": "38.000000",
+					"src_txid": "4d080ff1f8ac21d8c09a2dca99d28ae88e9441d7a4757dca68469ad64838cb55",
 					"hours": 3846,
 					"calculated_hours": 3846
 				}
@@ -5879,6 +6022,7 @@
 					"uxid": "6beca9fb58a327580c614d7fb5622916849756790b661bcabc880666364fdf47",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "863600.000000",
+					"src_txid": "345488861ad3f0d93024c367990e64ef0f7a95bd8b8589f554172f9439808263",
 					"hours": 20965,
 					"calculated_hours": 3029171
 				}
@@ -5922,6 +6066,7 @@
 					"uxid": "f8a1990492f970227ec29e6e095fa724d66fa2d6883bd8723773098d08ca8b3c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "801600.000000",
+					"src_txid": "da82deafc15c36e7dc9cd95663e0dc910ae626ee543147ac7bd8682be00f7baf",
 					"hours": 378646,
 					"calculated_hours": 378646
 				}
@@ -5965,6 +6110,7 @@
 					"uxid": "998487775c0e58420673b70204b83c1d6bb5b70e34b1aa0f8169c85ecec2438e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "765600.000000",
+					"src_txid": "211f5fc97ba1797d78f84d4e4db78415b5ff4121f78369535fe3f8015571c6df",
 					"hours": 47330,
 					"calculated_hours": 47330
 				}
@@ -6008,6 +6154,7 @@
 					"uxid": "6fb116c110fe391448a1dcb985b67439c2e9a71d8bb2fd1cf345ac73ada6166a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "755600.000000",
+					"src_txid": "9003d3caba9587d46d000cc614bb52bed34adcc5ea404c560c986eb6dd756e6b",
 					"hours": 5916,
 					"calculated_hours": 5916
 				}
@@ -6051,6 +6198,7 @@
 					"uxid": "04471fb0797bb931e883f7b95cfff6ee4fea5e19a352ca5425fcd353c4f6aba4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "750600.000000",
+					"src_txid": "e9a6dd585b564b19c55d9f56188a45bfad32fa75703fa6336830035f6fa92e3d",
 					"hours": 739,
 					"calculated_hours": 739
 				}
@@ -6095,6 +6243,7 @@
 					"uxid": "e2512ec90800147d0d9ddbd0778511ee5a45a25efcb354c50a101738a65462c5",
 					"owner": "YLT4buWf3kYDV9QddnC5iXTj881Eniuvrx",
 					"coins": "300.000000",
+					"src_txid": "8374d85130bbcf496bff138cd040f91fa362eb1b6b6a1c7c9285523437d5589c",
 					"hours": 3436,
 					"calculated_hours": 37891
 				},
@@ -6102,6 +6251,7 @@
 					"uxid": "6e2abc4bc7820178358a603b7d99c4b39735dd1685d0c5a778ab63f29c9e93d9",
 					"owner": "YLT4buWf3kYDV9QddnC5iXTj881Eniuvrx",
 					"coins": "700.000000",
+					"src_txid": "b7b42b1b29acab0a2328aaf368ec74be49b4d4caf827e82b439ef4d8be976a55",
 					"hours": 20200,
 					"calculated_hours": 100590
 				}
@@ -6146,6 +6296,7 @@
 					"uxid": "c5df36ce47f6f183475317ab1c53eaa65428c142cb3e3906bf162d80519a203f",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "12700.000000",
+					"src_txid": "6ce27da2ddbc15f03330960b4201dbb3a066ad2e9bbd5366a9564f6befdcae2e",
 					"hours": 2231,
 					"calculated_hours": 1175478
 				},
@@ -6153,6 +6304,7 @@
 					"uxid": "53b376413d550663ab51b229df8b0f55e4055d6577c2d8b5cec8ff748fe0e958",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "18000.000000",
+					"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 					"hours": 1388810,
 					"calculated_hours": 3051530
 				}
@@ -6197,6 +6349,7 @@
 					"uxid": "6b616ad99a946538c3ab101f245bcab211ab39507848425e80cbfc8ec5bdbc67",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "738100.000000",
+					"src_txid": "1ca0a2d44b6439b91eb839e0f99405abdcafe2c1a49c8b49b1739498129bd1a6",
 					"hours": 92,
 					"calculated_hours": 55430171
 				},
@@ -6204,6 +6357,7 @@
 					"uxid": "ef488d5f4a019502115d3b6b50bd364692315c3954d7e93c3ca22e11b92fc528",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "100.000000",
+					"src_txid": "243e1baa955c3f0af42d7acc4c920437dd0a99c754d6c5c2b7defcd143ff288d",
 					"hours": 528376,
 					"calculated_hours": 528376
 				}
@@ -6247,6 +6401,7 @@
 					"uxid": "8169bf7f8fa21dc6400b60678b302946cf2765f44893ec8466262fc69b710591",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "30600.000000",
+					"src_txid": "243e1baa955c3f0af42d7acc4c920437dd0a99c754d6c5c2b7defcd143ff288d",
 					"hours": 528376,
 					"calculated_hours": 534836
 				}
@@ -6290,6 +6445,7 @@
 					"uxid": "78126a08c4dd4ea7ca2d6c9f9d4614fa58896ec4ea301cb9b450104b00bc1b94",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "29600.000000",
+					"src_txid": "66d415598af081f8a7bd7f292468e67f380d06bf5896eb8152d4d9e8bcdf289e",
 					"hours": 66854,
 					"calculated_hours": 66854
 				}
@@ -6333,6 +6489,7 @@
 					"uxid": "ecb92dc2f43d4c6ca124575d8456d8894f3cb137875287beaa73180fcae2b3ca",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "737200.000000",
+					"src_txid": "c2c9fe882df3b44fbb125b251a7604a7a4f4195dddff6e5396b7f130744e2b27",
 					"hours": 6994818,
 					"calculated_hours": 101676076
 				}
@@ -6376,6 +6533,7 @@
 					"uxid": "6b4ca83b3f73b62161c90c6da03dff460ca9a5a3ccd6fafca140137416dedc58",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "736000.000000",
+					"src_txid": "6538399868cf772fcfa96e68c51aa6aa66faa95d7c685432e4005880932be134",
 					"hours": 12709509,
 					"calculated_hours": 12709509
 				}
@@ -6419,6 +6577,7 @@
 					"uxid": "2cd58783beb8a9f6278f7a097151531091b5f15afd7735e1facf02aa720c1191",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "735000.000000",
+					"src_txid": "3dfdfea4614d05c2f5eddf5773ef0afc745f1afe585141659df8e03e82897606",
 					"hours": 1588688,
 					"calculated_hours": 1588688
 				}
@@ -6462,6 +6621,7 @@
 					"uxid": "52288a441c70260f6a3eab0e271969d54492377615a6fba8ec3ad26f11dc9768",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "734500.000000",
+					"src_txid": "d30cec3ad3a66562d2513a3656b366ea7da583e6ba45214ac12b9c2219b4c5ea",
 					"hours": 198586,
 					"calculated_hours": 198586
 				}
@@ -6505,6 +6665,7 @@
 					"uxid": "e29ec214f4afd79e6465d03e4d88e552dc69654750a725d74873ee366c58e552",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "734400.000000",
+					"src_txid": "44d05abc2637d9cd2047984023eb5cfa0a146e58821117de30f9c81703189cde",
 					"hours": 24823,
 					"calculated_hours": 24823
 				}
@@ -6548,6 +6709,7 @@
 					"uxid": "8ea58a3736b35f0e3781e94198e8b73bba2536704b84b15900fb32701db8893e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "733400.000000",
+					"src_txid": "072f0738f834db0030d777e6ec0e0443627c51cecffcc55e41d43b0b8edd40d1",
 					"hours": 3102,
 					"calculated_hours": 3102
 				}
@@ -6591,6 +6753,7 @@
 					"uxid": "a1ed39cded6d9a0605b52f25cbedb363e57a168d1ad1d1db437816a401c061ab",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "732400.000000",
+					"src_txid": "b9a795552bec1a722718b44a08ad152656242b1d23afb53d2247b3016d920b7e",
 					"hours": 387,
 					"calculated_hours": 387
 				}
@@ -6634,6 +6797,7 @@
 					"uxid": "f89c968840831d03abaf3c41cf8a405e4b4ddbfb19f5ba300a8ea8e4dcb1d9a4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "731400.000000",
+					"src_txid": "fc02772662176c282c2b6538732d3d6eb1399f006a0b52e64d07fc104038f638",
 					"hours": 48,
 					"calculated_hours": 48
 				}
@@ -6677,6 +6841,7 @@
 					"uxid": "36972dc046829caa340eaecbfeb42f4174bcdecfb87296d56503e5fb10e9de8d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "730200.000000",
+					"src_txid": "9880bebc51471e0b3c520920db836d674f652503314cd74069a59ccad0d0967a",
 					"hours": 6,
 					"calculated_hours": 6
 				}
@@ -6720,6 +6885,7 @@
 					"uxid": "6962c7c1fcc98f532a9003990163bb251811a4700257968a641b1fe975cfc51d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "729200.000000",
+					"src_txid": "578075959959db70ae86f4f60d2ae3ff245727d086eef86ed80db5e1c7c9fbaf",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -6763,6 +6929,7 @@
 					"uxid": "d53fae3b48bde2d1328964a2e7f42e8e833983db159ba30f627926dea0db7df0",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "728200.000000",
+					"src_txid": "de45a24c9c32f808a3d928f30ba8e1b6ef8117a7c0b7a5d616734d9b121d0c30",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -6806,6 +6973,7 @@
 					"uxid": "228794e6b3eb69aecc5334e140afbad22883326dcf229bd3092f238ed9ec800f",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "725700.000000",
+					"src_txid": "16f8b9369f76ef6a0c1ecf82e1c18d5bc8ae5ef8b01b6530096cb1ff70bbd3fd",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -6849,6 +7017,7 @@
 					"uxid": "6efc30b4c943ba4de8d2c89901a0b2a4d9a0ecf34713917eae37c6debca616ed",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "724700.000000",
+					"src_txid": "030177271beee04f1a0974d0c5042f07c7ca1db1c5d496fbee3c441b1b7c5bee",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -6892,6 +7061,7 @@
 					"uxid": "6c8b1ba9dc7e8900b42d55e9fbe6ea0e00d7eaccf67a7b66c0a2b771cf88ea05",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "724200.000000",
+					"src_txid": "57150aecde96bde972183b9b0d7d27dda2c0179fb71630e92c27856d211335cd",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -6936,6 +7106,7 @@
 					"uxid": "c2fcd55cf6b73e863c96f7c2d6251069199bfd43688d2515f5c6631688aadcbc",
 					"owner": "bNQHMc2nM8x2fssmyUp6QWY1ow6LzB7kZz",
 					"coins": "1000.000000",
+					"src_txid": "e3b7236ad4b209d664ee1e2549f2a0d34a3ba58b12ee46f98fba73c01574e484",
 					"hours": 5,
 					"calculated_hours": 396519
 				},
@@ -6943,6 +7114,7 @@
 					"uxid": "06292fe8a2036c38f28c4d2f355d9e86e2b55b9d85f84613a64cf5c35d192b28",
 					"owner": "bNQHMc2nM8x2fssmyUp6QWY1ow6LzB7kZz",
 					"coins": "1000.000000",
+					"src_txid": "bbd1d4b6fe89a5986efbea9f7996cca2a515c3f0788cedccc21990dc78d83509",
 					"hours": 43,
 					"calculated_hours": 396554
 				}
@@ -6980,6 +7152,7 @@
 					"uxid": "59d44fefbe86ebae4118dee90609d6a1c08c36f259c65e3fad63b9e41c37bf0c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "723200.000000",
+					"src_txid": "3bb9fc516dc2c522e28f99e6833253863c550547ce0e0a2dd963a0118b7a44a7",
 					"hours": 0,
 					"calculated_hours": 9192675
 				}
@@ -7023,6 +7196,7 @@
 					"uxid": "5baf8c8ab1a01d80a6f496144815cf6bda5289b34055010e21324ea3950d3299",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "722200.000000",
+					"src_txid": "5701965d326520f86335da87c6d1781fd49f1e66520b94e1783711eba724f482",
 					"hours": 1149084,
 					"calculated_hours": 1149084
 				}
@@ -7066,6 +7240,7 @@
 					"uxid": "dd07d759d92e3d628a35c467dcd919dcae825a9fa79a14855714270dae08c0ce",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "721200.000000",
+					"src_txid": "3fae944ef07d9bcba1bcbc8bde87da50a1232132074803f8442deb563ed2da51",
 					"hours": 143635,
 					"calculated_hours": 143635
 				}
@@ -7109,6 +7284,7 @@
 					"uxid": "c739b518f3f700e810f81523d81b15f968fbf202f389ceaa9d9f303319a00275",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "720200.000000",
+					"src_txid": "79681167a7681edecb998e4a6dccdd0b7be45f163c8f6db23436517936269fb8",
 					"hours": 17954,
 					"calculated_hours": 17954
 				}
@@ -7152,6 +7328,7 @@
 					"uxid": "95694746f813d018be7988aec666b52924a7815adabe9cbdac3f6ab0f51bd1ab",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "719200.000000",
+					"src_txid": "b69536fbec9911da41e9d0c5ca73459f5e692ba155f8b72c0972792e9937a0fe",
 					"hours": 2244,
 					"calculated_hours": 2244
 				}
@@ -7195,6 +7372,7 @@
 					"uxid": "be958e5c47415291a781648335db24e448e1f4f09aa5e9c3f055fbc906b574d7",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "719100.000000",
+					"src_txid": "3e228564e3c187e22bd489857fdb1db7036021e19f688aad56cfee57d5e13ac5",
 					"hours": 280,
 					"calculated_hours": 280
 				}
@@ -7238,6 +7416,7 @@
 					"uxid": "68165429853e18e4414ec6c15630262ebcaa802ff1d83b6cbe116db51cb32066",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "718100.000000",
+					"src_txid": "18607765c3fbd45eafa15d2d62ab3cbc7ba7bd80c42931aae4db75aa02898671",
 					"hours": 35,
 					"calculated_hours": 35
 				}
@@ -7281,6 +7460,7 @@
 					"uxid": "46aeb9ea01bb04e28c55ef11f8e75434dbeee546f7e06bdef332c604590c48a1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "717100.000000",
+					"src_txid": "dc10e0565a14dfecda066577581f3e2d073de34ed3e911ed94413d38fc0a33d2",
 					"hours": 4,
 					"calculated_hours": 4
 				}
@@ -7324,6 +7504,7 @@
 					"uxid": "598503902d2e6cb62d6f6478f09d8da05af6fd2da92b50825da3b7f74b2df34c",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "716100.000000",
+					"src_txid": "b0d7ff47658b3e32d8457eb62f6df0c7caaf7feadcbf8cc0c713976026f0404c",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7367,6 +7548,7 @@
 					"uxid": "4b917e7bd3409c43f9f670f2846ce74f9288708df5aa1d9ae142f2411ce426da",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "715100.000000",
+					"src_txid": "be0957035ed2ac444f67273fc5c1c6a39ee373f6f83d1604d0023742a8cd7e42",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7410,6 +7592,7 @@
 					"uxid": "d50a372f8f8cd1e0b10d847613b68ee760f195f5f212d6c59e86312c84dd07ac",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "714800.000000",
+					"src_txid": "c9582c8134fa64fdf08cd93d42035adcced3f16aa8ee1a1393e3fcd7c07aa40c",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7453,6 +7636,7 @@
 					"uxid": "896865f9b610f9fb69a741596b3ecb9fff3790d40476a9f7852831bdf477aaee",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "713800.000000",
+					"src_txid": "29a883ef9dc67bc683014187b9865c827b5e2f8afd7bf6f3787483318063789e",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7496,6 +7680,7 @@
 					"uxid": "272d5bbd86a87796a20e3e4debc46a2076718800343bee4f72fc0217a98a10a3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "695800.000000",
+					"src_txid": "c3fd04cd27ea311b1a67d40cd3dbb2ea8ae2c6f6139620cb86be29f33ed99171",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7539,6 +7724,7 @@
 					"uxid": "60906201d3e7c67ddb976972460b2b8ed093e1f6720a784cbaea376ca13e6cef",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "670800.000000",
+					"src_txid": "3d9f1aa1b6206275081cb9c26155f6261be1ef9c94b4eaadb1a7e8277a2099fa",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7582,6 +7768,7 @@
 					"uxid": "4912e9dbbb5a4cc7472c27b0212ab443e7b5499207b10666a66257005e182714",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "664464.000000",
+					"src_txid": "d720ca0efb19b964f481724e5d3f932841e9e75a69b998baf4b575cf3298cb87",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7625,6 +7812,7 @@
 					"uxid": "659bac1636b64087ad5d3cb0ae78c52f28ad920016ec67e08415a537e0343072",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "663464.000000",
+					"src_txid": "0e8e352b1f2cd419bca619918ce6d5ec1eac0ba7252d76eef5d9d8f8186f737a",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7668,6 +7856,7 @@
 					"uxid": "97f64c3c636e5fc997e277cd48644055ef51045ed9c473c05dd6e699872a6c3d",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "662464.000000",
+					"src_txid": "d5091ca65ff61998dfb4535a7927fb736abf2a81140a11322dcf8226de27cf92",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7711,6 +7900,7 @@
 					"uxid": "122b7a9a61ee04e071002d74ffb26b12ed7952ff9a138b5437f990f4678cc2e5",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "662314.000000",
+					"src_txid": "30e66ff45cfb145eb465e2ebdef0bb10005138bc1727c83888785b04d548e85b",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7754,6 +7944,7 @@
 					"uxid": "c07593d4329f82da243e4bbd7430e4b10e7b35f9ce0a3718d0e6d25d20b4939b",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "661314.000000",
+					"src_txid": "ec79854fade530d84099d5619864a8e1e8ec9d27a086917a239500cada43c6e8",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7797,6 +7988,7 @@
 					"uxid": "4d52106e41dba0099549fd81fb8feb6915225b0125c53faa0f7c578ea78f213a",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "660314.000000",
+					"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -7841,6 +8033,7 @@
 					"uxid": "37cc43693a024f9122f5e1fcabeab5d53a4d58590df30a934fc7bc545936e049",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "1000.000000",
+					"src_txid": "2df67e974b03b46be4e59fcf2f8b751d501f17f8610d5adf94551a7ecc6a58af",
 					"hours": 8356,
 					"calculated_hours": 141306
 				},
@@ -7848,6 +8041,7 @@
 					"uxid": "903a1bca9b81ed76179cbcffe6e3c8eff269c94826148286f7be0b6038ee4ccb",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "28600.000000",
+					"src_txid": "2df67e974b03b46be4e59fcf2f8b751d501f17f8610d5adf94551a7ecc6a58af",
 					"hours": 8356,
 					"calculated_hours": 3810733
 				}
@@ -7891,6 +8085,7 @@
 					"uxid": "fef9dd3b633274743099e607d9229717a001d6de6a4031479cc30d31d65e8396",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "659314.000000",
+					"src_txid": "3991a257eee265481e713917a3a9c15756f61175bcfc7acfdbe84158e43fd5e6",
 					"hours": 0,
 					"calculated_hours": 269219
 				}
@@ -7934,6 +8129,7 @@
 					"uxid": "21f0fb666dca05d7a43ab26a378f7f7eaedfacde22fa047ca72857e9509cc748",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "659214.000000",
+					"src_txid": "b29222c08f10b8bc4ea18981519a3b0e02b9c9cec63ee28d9ffa2efcaf2a8e5a",
 					"hours": 33652,
 					"calculated_hours": 33652
 				}
@@ -7977,6 +8173,7 @@
 					"uxid": "bc513a68461d5c401e65a500baf7dfa163735ef63b817bb7b73c4139d5c29d18",
 					"owner": "212mwY3Dmey6vwnWpiph99zzCmopXTqeVEN",
 					"coins": "1000.000000",
+					"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 					"hours": 0,
 					"calculated_hours": 561
 				}
@@ -8020,6 +8217,7 @@
 					"uxid": "bffea1990d71311b695b2d343b9f09a216b7a8257c1cdcb01b2ab9459e1490e3",
 					"owner": "jtuSERvfzN3kUYekg8LemCQ5kF5g97N8ZL",
 					"coins": "10.000000",
+					"src_txid": "acfb61f7ca39d5dfe33e8ed66f73ab181da0a3206d457bf055dcc4b9731a3ec8",
 					"hours": 70,
 					"calculated_hours": 70
 				}
@@ -8057,6 +8255,7 @@
 					"uxid": "6b3a0cab1d9ad6fd011a3bac5e6ff4e3f7903bce911dc7fe83926eae557c34c3",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "658214.000000",
+					"src_txid": "50fc81b0ba25669105a169a969459ccdb10278051b604a3f91467c2528c83652",
 					"hours": 4206,
 					"calculated_hours": 8113036
 				}
@@ -8100,6 +8299,7 @@
 					"uxid": "074645413ab2aae818e657f6f36420447a872e7cdd2ff64324b486be4d4d1edd",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "29100.000000",
+					"src_txid": "41589644ea3a344fc616bec0058cf916b8efa5da7c3539241244827bd7e19811",
 					"hours": 494004,
 					"calculated_hours": 1132102
 				}
@@ -8143,6 +8343,7 @@
 					"uxid": "372703f8109295f0f58fbee58795979e10dd887869f4fc1da4881ce8a3c0aeb4",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "647750.000000",
+					"src_txid": "fb495093f2f4e5c6555c50150ea60c0a6f430e53aa971ebb3e2b5412866a1f06",
 					"hours": 1014129,
 					"calculated_hours": 1019526
 				}
@@ -8186,6 +8387,7 @@
 					"uxid": "b1b832a911d45aeaab73676caad794fe2ab99d423f80c4ff58cfb269656b03dd",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "28100.000000",
+					"src_txid": "7abef7e4080bf2cbe9f147d7c9cbe4c950b38f8477d304466c938b937cd379ba",
 					"hours": 141512,
 					"calculated_hours": 148693
 				}
@@ -8229,6 +8431,7 @@
 					"uxid": "14027340f6e1d98bba3f7f5f3b50e3588f8a19e4d021db944e7a28b2643640e1",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "635750.000000",
+					"src_txid": "a7665cec98224150968ec1ef9ef2d6b3175c9de8f9f8c7bc786b30cc74997c57",
 					"hours": 127440,
 					"calculated_hours": 146865
 				}
@@ -8285,6 +8488,7 @@
 					"uxid": "04c0cd4cbee1e5414791d9e0b9ae4f889bc52d253b5f70b09fbc32c88fb415ae",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "3.000000",
+					"src_txid": "fa33df7c4316cea05095e6c7ce86f361847893d26fe2255af118593a33686c52",
 					"hours": 4,
 					"calculated_hours": 1748
 				},
@@ -8292,6 +8496,7 @@
 					"uxid": "f3034ffe54e869315f8e11801d3e755352fb75b878b24313302273c1b7ea62cb",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1.000000",
+					"src_txid": "fa33df7c4316cea05095e6c7ce86f361847893d26fe2255af118593a33686c52",
 					"hours": 0,
 					"calculated_hours": 581
 				},
@@ -8299,6 +8504,7 @@
 					"uxid": "3538af0016ec0f4d0e943c5d49daf280b416701fde4040fa72710c0ca1b5b559",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1.000000",
+					"src_txid": "b68d78c9a4610b540933eaa550fbb1c473f5cf749eb522882f8154d495453e7d",
 					"hours": 0,
 					"calculated_hours": 581
 				},
@@ -8306,6 +8512,7 @@
 					"uxid": "0560bae3917bca7581af9b6c5a58e395c701ce9ed0241dac2de8a3e93c0b839b",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1000.000000",
+					"src_txid": "77a69f4c8afd858a2f6767bb9980d4af6520e02b076bf2a78b935021e1147c71",
 					"hours": 1605,
 					"calculated_hours": 510237
 				},
@@ -8313,6 +8520,7 @@
 					"uxid": "3fe7d61ffa993e00200ce6be7ba347c603032ac3f8c4ace07767e630fe94d76c",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1000.000000",
+					"src_txid": "0cded82aa3ac92d78e23d2d0d7faf93c675fc9a321ad55105f65b6fca444b1e7",
 					"hours": 125696,
 					"calculated_hours": 610213
 				},
@@ -8320,6 +8528,7 @@
 					"uxid": "2a09e97f7725a35af1357842206875a023252da4ebfce129eaf4cb87119cfd41",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1000.000000",
+					"src_txid": "bd617ec27c2bea642fad8c153178e11ca08456d752249324e3011f27c845f87a",
 					"hours": 2704,
 					"calculated_hours": 487118
 				},
@@ -8327,6 +8536,7 @@
 					"uxid": "617b584bb9e6b1d80daac915fb3079b22a326777d1515a40e7b7eddf427f4099",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1000.000000",
+					"src_txid": "072f0738f834db0030d777e6ec0e0443627c51cecffcc55e41d43b0b8edd40d1",
 					"hours": 3102,
 					"calculated_hours": 163688
 				},
@@ -8334,6 +8544,7 @@
 					"uxid": "18293d947aadf89d9e57d18fa01408867a9abe267504edbdabf8c2a57d9a6323",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1000.000000",
+					"src_txid": "030177271beee04f1a0974d0c5042f07c7ca1db1c5d496fbee3c441b1b7c5bee",
 					"hours": 0,
 					"calculated_hours": 112148
 				},
@@ -8341,6 +8552,7 @@
 					"uxid": "045dc2e76321e37884588093083ce1b21be12f20ba1fa36f2a755b894229e3cf",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1000.000000",
+					"src_txid": "b0d7ff47658b3e32d8457eb62f6df0c7caaf7feadcbf8cc0c713976026f0404c",
 					"hours": 0,
 					"calculated_hours": 73857
 				},
@@ -8348,6 +8560,7 @@
 					"uxid": "b1e5c694c30326cda3df2e634723999befbcbb141415e9a36bdbf18d7bea9870",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "6336.000000",
+					"src_txid": "d720ca0efb19b964f481724e5d3f932841e9e75a69b998baf4b575cf3298cb87",
 					"hours": 0,
 					"calculated_hours": 340570
 				},
@@ -8355,6 +8568,7 @@
 					"uxid": "db7a63750db787959a9e0d2d6be9a1ba8bb3d6015bae2353a27ae9eb55b39d22",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "150.000000",
+					"src_txid": "30e66ff45cfb145eb465e2ebdef0bb10005138bc1727c83888785b04d548e85b",
 					"hours": 0,
 					"calculated_hours": 5180
 				},
@@ -8362,6 +8576,7 @@
 					"uxid": "5954742a6ca4e3e872d12d4a93436451ad52e6d25e5ac28371e308b2d7ce75a3",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1000.000000",
+					"src_txid": "3991a257eee265481e713917a3a9c15756f61175bcfc7acfdbe84158e43fd5e6",
 					"hours": 0,
 					"calculated_hours": 32930
 				},
@@ -8369,6 +8584,7 @@
 					"uxid": "a35044035cce79cb988c757dcaf5d9a065957c0fbc1a3559d08ed46831504fc2",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "10464.000000",
+					"src_txid": "fb495093f2f4e5c6555c50150ea60c0a6f430e53aa971ebb3e2b5412866a1f06",
 					"hours": 1014129,
 					"calculated_hours": 1124989
 				},
@@ -8376,6 +8592,7 @@
 					"uxid": "c31c199a54ecbea5e57bf7f5e73d231a09e11713dd0ee70e340e4b0a9c9f9fdc",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "1000.000000",
+					"src_txid": "7abef7e4080bf2cbe9f147d7c9cbe4c950b38f8477d304466c938b937cd379ba",
 					"hours": 141512,
 					"calculated_hours": 152098
 				}
@@ -8419,6 +8636,7 @@
 					"uxid": "d6735d3ad70dbf553048faf1c529d047ab12282d04e320bd67c915779fc4e3fd",
 					"owner": "NGLS4CYvBdV9HXJDpeY8jrdQDqLeBvfAwc",
 					"coins": "24950.000000",
+					"src_txid": "a17cf54c20ac7ec6e1362acf24c5e5589ed8b49bdba791a87430de160a473913",
 					"hours": 451992,
 					"calculated_hours": 451992
 				}
@@ -8462,6 +8680,7 @@
 					"uxid": "a5f3c513b5a01dc5e943a5cae91f54b54cde55e984a9480d68d690f40dfb7914",
 					"owner": "v4qF7Ceq276tZpTS3HKsZbDguMAcAGAG1q",
 					"coins": "5.000000",
+					"src_txid": "a17cf54c20ac7ec6e1362acf24c5e5589ed8b49bdba791a87430de160a473913",
 					"hours": 451992,
 					"calculated_hours": 451992
 				}
@@ -8499,6 +8718,7 @@
 					"uxid": "8e55f10a0615a0737e6906132e09ac08a206971ba4b656f004acc7f4b7889bc8",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "625750.000000",
+					"src_txid": "9364ed6cfcc289df74dc6bac1993f7ab3441b898cb3f06918198d2476c83dbac",
 					"hours": 18358,
 					"calculated_hours": 44173190
 				}
@@ -8542,6 +8762,7 @@
 					"uxid": "c39acd3494113650c1a6a7809287af7b12a78bbd97126d4585dd1715e2cb5a66",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "23100.000000",
+					"src_txid": "ad44a8027a825e82a20cdd910d9bd41d74025601b7668c80655e9b45afb8bb93",
 					"hours": 18586,
 					"calculated_hours": 3020347
 				}

--- a/src/api/integration/testdata/genesis-addr-transactions-verbose.golden
+++ b/src/api/integration/testdata/genesis-addr-transactions-verbose.golden
@@ -49,6 +49,7 @@
 					"uxid": "043836eb6f29aaeb8b9bfce847e07c159c72b25ae17d291f32125e7f1912e2a0",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "100000000.000000",
+					"src_txid": "0000000000000000000000000000000000000000000000000000000000000000",
 					"hours": 100000000000000,
 					"calculated_hours": 100000000000000
 				}
@@ -680,6 +681,7 @@
 					"uxid": "fa2b598d233fe434f907f858d5de812eacf50c7b3fd152c77cd6e246fe356a9e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "999890.000000",
+					"src_txid": "0579e7727627cd9815a8a8b5e1df86124f45a4132cc0dbd00d2f110e4f409b69",
 					"hours": 4073,
 					"calculated_hours": 6061184
 				}
@@ -723,6 +725,7 @@
 					"uxid": "c603e99ceae4d15c20360714ee07ba6e3a944a97ea9285d164c23252e93958b6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "d952ef4cc45a89c14230ba0f7e30b782fad83cb6506ac0f503a242c568c1287a",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -760,6 +763,7 @@
 					"uxid": "18ea1b3cceb2ca40c01efc8f3cfd7d1d0dd69430ecdf655515aa4f8b21bd2644",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "260d249883165aa9e59e17fb2bd8ba8995d2c3644993530985f8b813ed378650",
 					"hours": 78,
 					"calculated_hours": 78
 				}
@@ -803,6 +807,7 @@
 					"uxid": "64194899d317e2a007f89df14538795547e927c242a92f83180e6cc952304964",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "5.000000",
+					"src_txid": "9004c779cff67b3895500ec14b2c2e566127bb11a8af3358fe8a63dcfae9badc",
 					"hours": 9,
 					"calculated_hours": 9
 				}
@@ -841,6 +846,7 @@
 					"uxid": "569aa1260e734017c4eee06d84ab4a6285e2ca2041940b2915d9141527caf179",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "5.000000",
+					"src_txid": "9004c779cff67b3895500ec14b2c2e566127bb11a8af3358fe8a63dcfae9badc",
 					"hours": 9,
 					"calculated_hours": 9
 				},
@@ -848,6 +854,7 @@
 					"uxid": "eb446b8372559249c8e269b6cd028588e2e9e4f8fe9357719da9d1c22aa29911",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "5.000000",
+					"src_txid": "327375203f20cb68847351c30a48597c0588a8c14319a4eb47bf440207fd045a",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -885,6 +892,7 @@
 					"uxid": "e702df2703c3de180f3e4a0e9a503bd534037c2d68e858e97a317575c5a97d95",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "e89ee3e90e72108e4cd6ccb95c9f8d2b18ccfaa7ce61a7d297454debd69cebbf",
 					"hours": 1,
 					"calculated_hours": 1
 				}
@@ -928,6 +936,7 @@
 					"uxid": "10998e83dc5dfe3c3f5f28ef3e5e2fced4dbd1da389678b0ea3ddb552851b6bf",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "6.000000",
+					"src_txid": "08bf0f8f4a8547bcab1fef035adac2a66c80369b4485a736bdd676e782bbb037",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -966,6 +975,7 @@
 					"uxid": "41c6d29aa5de770de684ab19b40bd75b99ec7f1a5ff7d15288ae4bfff568eabd",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "4.000000",
+					"src_txid": "08bf0f8f4a8547bcab1fef035adac2a66c80369b4485a736bdd676e782bbb037",
 					"hours": 0,
 					"calculated_hours": 0
 				},
@@ -973,6 +983,7 @@
 					"uxid": "9e5779445f60d62b471862339d7a83dd8355c7a89d5fc3b751f98e9414628ec2",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "6.000000",
+					"src_txid": "3170f0635cc40aded3a38f84f2ae07bd2238550ea4ee867328d0f891ea9abf14",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1010,6 +1021,7 @@
 					"uxid": "d46e91fea3c8a6428885f941e5152dbc7f9abd356ad4d054bf20e0e806f1ec99",
 					"owner": "qxmeHkwgAMfwXyaQrwv9jq3qt228xMuoT5",
 					"coins": "10.000000",
+					"src_txid": "fba515a9eeaedb891c4dca862bd06108e0452270890b362f0b353b4c86845618",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -1047,6 +1059,7 @@
 					"uxid": "cb8efc0b1082c39258cb6efd59f64d88b36fcb60143c826829fc5f0ed5c0d668",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944790.000000",
+					"src_txid": "df622e8c9dfaed1d7dca83ad7f6d8946bb86b81398bad521d858cbefef8e4688",
 					"hours": 400470,
 					"calculated_hours": 400470
 				}
@@ -1090,6 +1103,7 @@
 					"uxid": "a6061defc41a8a55e37eaf56ebaa1177446f61719b1d5126698e79a6023f5367",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944780.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50058
 				}
@@ -1133,6 +1147,7 @@
 					"uxid": "3b5f72e772ea886dd872b9087395398133576a6561072d5294fbcd04b49e1d95",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944770.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6257
 				}
@@ -1176,6 +1191,7 @@
 					"uxid": "f265bea876ffcfb8cf64df3aca4dae4a8d7f424ff495d91fb322feddb3a7e505",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944760.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 782
 				}
@@ -1223,6 +1239,7 @@
 					"uxid": "2987e7c89d353ad5d63cea2bf2724dc5f7a5ef5fb81f5ea160a307f0726ac2f5",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "9fb039cd90a4e9b85669bd6ef878b98a9e84eec7d4804e2bff6f0dc9c2739c44",
 					"hours": 0,
 					"calculated_hours": 701
 				},
@@ -1230,6 +1247,7 @@
 					"uxid": "a52408daa8ce7026c70b61d4df4212fb577462060f340bfce779225b3e18193d",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "0a2da0489b14156fad8fb863d051a4dac1f645f144c1e5bb65a44478623b8e4b",
 					"hours": 50058,
 					"calculated_hours": 50605
 				},
@@ -1237,6 +1255,7 @@
 					"uxid": "dc73aac74348dd285a1456c1fae2204d7c2039d50a765bdaae0c31f7c7e059db",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "a4a202bc4431d95c307d151dea764bfc6d9ceb7e82b3eb50dc8604050622a22c",
 					"hours": 6257,
 					"calculated_hours": 6804
 				},
@@ -1244,6 +1263,7 @@
 					"uxid": "e4e375b9dc55ff53d6de9120f1a87ff00e00a779835f8320f2c6b3090d0466e6",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "4e6b363423633ad51114b250478ee7645fbd184066fa41c29e5b14d0728cdfec",
 					"hours": 782,
 					"calculated_hours": 1329
 				},
@@ -1251,6 +1271,7 @@
 					"uxid": "d11b05345917d171f60c31bd2634041b73b97eae364724369ddb8d53369397fb",
 					"owner": "2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6",
 					"coins": "10.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 644
 				}
@@ -1288,6 +1309,7 @@
 					"uxid": "998487775c0e58420673b70204b83c1d6bb5b70e34b1aa0f8169c85ecec2438e",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "765600.000000",
+					"src_txid": "211f5fc97ba1797d78f84d4e4db78415b5ff4121f78369535fe3f8015571c6df",
 					"hours": 47330,
 					"calculated_hours": 47330
 				}

--- a/src/api/integration/testdata/multiple-addr-transactions-verbose.golden
+++ b/src/api/integration/testdata/multiple-addr-transactions-verbose.golden
@@ -22,6 +22,7 @@
 					"uxid": "108520145179c00f581d91e273714811fe6e82ee059d65218eea91154ebd8205",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "998790.000000",
+					"src_txid": "a76cd63b71f1f5425941cd567627e1dcdc8c34306a7945ea48755f5a46efb6f5",
 					"hours": 389245,
 					"calculated_hours": 389245
 				}
@@ -65,6 +66,7 @@
 					"uxid": "e6d9b56e075a6adf520d1ae7fbab9ae06353ae0b93dc8cb17d82cc3628009a50",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944750.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 23715
 				}
@@ -108,6 +110,7 @@
 					"uxid": "df5d6e09da2585a6ac1a37aea2370fa25e9049b549049202d5417138bf033cfa",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "10000.000000",
+					"src_txid": "c38b47bd576e3bced2a9309c3df7622064e71177f54020d77193d5cac310719c",
 					"hours": 48655,
 					"calculated_hours": 101571
 				}
@@ -151,6 +154,7 @@
 					"uxid": "3d7dd4d41e613fe8153f5e5f62b79494e9db9ed98f875d929ca1f90ecfe2d50b",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "9000.000000",
+					"src_txid": "8fba29db2e3e8cad785e723f95aa5fa46ae0dd8b2bb62586977f20e698642cfb",
 					"hours": 12696,
 					"calculated_hours": 12846
 				}
@@ -194,6 +198,7 @@
 					"uxid": "77769e6a01cf3dca201ade501767d0abf20dea19d694f3272b647a9a651fdee9",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "8000.000000",
+					"src_txid": "77a69f4c8afd858a2f6767bb9980d4af6520e02b076bf2a78b935021e1147c71",
 					"hours": 1605,
 					"calculated_hours": 1693
 				}
@@ -237,6 +242,7 @@
 					"uxid": "450cd7795bb3625daa99d6b64b9a8786d593bf1cad986d6c2933dae04b74a593",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "888750.000000",
+					"src_txid": "f51e2ce31961b0186e04cc9d78857c3c21d3e2afb25c050d8c1d67d3320fcc07",
 					"hours": 2,
 					"calculated_hours": 2
 				}
@@ -280,6 +286,7 @@
 					"uxid": "c7919b892eeb751456d456b37ccde7350a3fca0dda03b17ec426a56f12dcf192",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "1000.000000",
+					"src_txid": "d154d8262abbf517c67d529b0fea7cdf097433bd296d5795b17c6379cb1b1430",
 					"hours": 2964,
 					"calculated_hours": 3100
 				}
@@ -324,6 +331,7 @@
 					"uxid": "f5867b05823c81fc53de36b140415b3b98e4f4cec5883512f8553f70c550d8e7",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "7000.000000",
+					"src_txid": "8d10b0ba11d9dd63d3a3522bc35bd260e8da9109298aa488355ea7201eb961b7",
 					"hours": 211,
 					"calculated_hours": 136742
 				},
@@ -331,6 +339,7 @@
 					"uxid": "22edb5931e1c54382f18e41ef774931efb08c278209a1fe8a34100147b707220",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "25000.000000",
+					"src_txid": "abed13c2a552633d26b5b51c3ac5abf9808756c0203869ed185a7cd673702ba2",
 					"hours": 0,
 					"calculated_hours": 485597
 				}
@@ -374,6 +383,7 @@
 					"uxid": "09661724179523e8aec95862a5fd12dd1aa50f39f193f81eece0d7aea6197103",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "31000.000000",
+					"src_txid": "2558a7cd524acdb58f822a56bd51e8905182b2b35fbfdb1246ce6dc9930d14eb",
 					"hours": 77792,
 					"calculated_hours": 219961
 				}
@@ -417,6 +427,7 @@
 					"uxid": "6a8bc7ef9e8e7b67fd270cf37022edadb13f1fc2ba4e7a026f7ce2ab30cc4572",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "30000.000000",
+					"src_txid": "d80d49958166fd7b35cee63cfc4a4fdd434484f9bfd9444f62a1b856da36e9c7",
 					"hours": 27495,
 					"calculated_hours": 27495
 				}
@@ -460,6 +471,7 @@
 					"uxid": "15700b88043b3c08a46c3c4e36e7f431291a26aef1ef26c44ee413feee14b950",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "29700.000000",
+					"src_txid": "8374d85130bbcf496bff138cd040f91fa362eb1b6b6a1c7c9285523437d5589c",
 					"hours": 3436,
 					"calculated_hours": 5086
 				}
@@ -503,6 +515,7 @@
 					"uxid": "24c49699aab32caf9456a6b4dacd4d820c853c7639e5500b3be6326660312917",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "28700.000000",
+					"src_txid": "a0956843d442bd4b592d0c1323d153c3c1b2d7d52a86629444de6d1d1b6a4c33",
 					"hours": 635,
 					"calculated_hours": 1033
 				}
@@ -546,6 +559,7 @@
 					"uxid": "fb4d5dcc1c3ac97444e96aa7da392b0d7faf7b7373504c70e497228a4695a7f1",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "27700.000000",
+					"src_txid": "e2d9da9342b21659da0a679536f9d6f533a4ce7dc33a7f768c3441ca3640458d",
 					"hours": 129,
 					"calculated_hours": 436
 				}
@@ -589,6 +603,7 @@
 					"uxid": "4e75b4bced3404590d38ca06440c275d7fd86618a84966a0a1053fb18164e898",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26700.000000",
+					"src_txid": "a689a3589730a351f880176b2c15b395967b38a90950e0491e7a1e5531f020a9",
 					"hours": 54,
 					"calculated_hours": 811481
 				}
@@ -626,6 +641,7 @@
 					"uxid": "0a5603a1a5aeda575aa498cdaec5a4c893a28669dba84163eba2e90db3d9f39d",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26700.000000",
+					"src_txid": "7b13cab45b52dd2df291ec97cf000bf6ea1b647d6fdf0261a7527578d8b71b9d",
 					"hours": 101435,
 					"calculated_hours": 101435
 				}
@@ -669,6 +685,7 @@
 					"uxid": "1e30e9dfe00e055404063e52a4154a72492b13de6acf4871ec5ea6d7c0fcc968",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26600.000000",
+					"src_txid": "9150311508851ca989efb5f82b5a7201724514b6b9f84ec1620c18673462126b",
 					"hours": 12679,
 					"calculated_hours": 14895
 				}
@@ -712,6 +729,7 @@
 					"uxid": "1d4595b9fa1c6c3d64f48b6ae5f8f861b1c08a022cbcb04b279df448da3db660",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873900.000000",
+					"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 					"hours": 1388810,
 					"calculated_hours": 1388810
 				}
@@ -755,6 +773,7 @@
 					"uxid": "2426f768e00345b641f5b4b4b058c308d528e22437bc6e552f0a9d5bd665e14a",
 					"owner": "2JJ8pgq8EDAnrzf9xxBJapE2qkYLefW4uF8",
 					"coins": "26500.000000",
+					"src_txid": "41ec724bd40c852096379d1ae57d3f27606877fa95ac9c082fbf63900e6c5cb5",
 					"hours": 1861,
 					"calculated_hours": 518287
 				}
@@ -799,6 +818,7 @@
 					"uxid": "7b132c07322babefa83ab64971b7bfb29bf2cb9ffe9c42dc7e2975a185dcd8b8",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "995.000000",
+					"src_txid": "a95317361364e8cc08a150840bac8a97ea1f56278f8834ca2a2f16c24c4a7f0f",
 					"hours": 387,
 					"calculated_hours": 72454
 				},
@@ -806,6 +826,7 @@
 					"uxid": "c961ba554ae30b0edcdf71e834ab2b26d7dff5bcf5955d4874cdba89170392bf",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "100.000000",
+					"src_txid": "1f27afc41896d2c7fdbd2620e606440ad12557e9a4bdd6808dcc2c23d4e32978",
 					"hours": 173601,
 					"calculated_hours": 173704
 				}
@@ -849,6 +870,7 @@
 					"uxid": "f480c6097568036b90a2e019f9ee68c0812b2da8828be33a005a7427caf14a2b",
 					"owner": "f38daJDg8rpwL5xWgMY78fBHncQ1N5gQZ7",
 					"coins": "38.000000",
+					"src_txid": "4d080ff1f8ac21d8c09a2dca99d28ae88e9441d7a4757dca68469ad64838cb55",
 					"hours": 3846,
 					"calculated_hours": 3846
 				}
@@ -886,6 +908,7 @@
 					"uxid": "6beca9fb58a327580c614d7fb5622916849756790b661bcabc880666364fdf47",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "863600.000000",
+					"src_txid": "345488861ad3f0d93024c367990e64ef0f7a95bd8b8589f554172f9439808263",
 					"hours": 20965,
 					"calculated_hours": 3029171
 				}

--- a/src/api/integration/testdata/single-addr-transactions-verbose.golden
+++ b/src/api/integration/testdata/single-addr-transactions-verbose.golden
@@ -22,6 +22,7 @@
 					"uxid": "e6d9b56e075a6adf520d1ae7fbab9ae06353ae0b93dc8cb17d82cc3628009a50",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "944750.000000",
+					"src_txid": "edc27c6ecc1f76d0f23489ad7bbbdb8c653af37cc4b8f18197400aea2011ed83",
 					"hours": 97,
 					"calculated_hours": 23715
 				}
@@ -65,6 +66,7 @@
 					"uxid": "c7919b892eeb751456d456b37ccde7350a3fca0dda03b17ec426a56f12dcf192",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "1000.000000",
+					"src_txid": "d154d8262abbf517c67d529b0fea7cdf097433bd296d5795b17c6379cb1b1430",
 					"hours": 2964,
 					"calculated_hours": 3100
 				}
@@ -108,6 +110,7 @@
 					"uxid": "1d4595b9fa1c6c3d64f48b6ae5f8f861b1c08a022cbcb04b279df448da3db660",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "873900.000000",
+					"src_txid": "f8a24a25a8e3b206db7ea8a0bd8eeb0f8087f50d230c81a538316bcc5152da3d",
 					"hours": 1388810,
 					"calculated_hours": 1388810
 				}
@@ -152,6 +155,7 @@
 					"uxid": "7b132c07322babefa83ab64971b7bfb29bf2cb9ffe9c42dc7e2975a185dcd8b8",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "995.000000",
+					"src_txid": "a95317361364e8cc08a150840bac8a97ea1f56278f8834ca2a2f16c24c4a7f0f",
 					"hours": 387,
 					"calculated_hours": 72454
 				},
@@ -159,6 +163,7 @@
 					"uxid": "c961ba554ae30b0edcdf71e834ab2b26d7dff5bcf5955d4874cdba89170392bf",
 					"owner": "2kvLEyXwAYvHfJuFCkjnYNRTUfHPyWgVwKt",
 					"coins": "100.000000",
+					"src_txid": "1f27afc41896d2c7fdbd2620e606440ad12557e9a4bdd6808dcc2c23d4e32978",
 					"hours": 173601,
 					"calculated_hours": 173704
 				}
@@ -202,6 +207,7 @@
 					"uxid": "f480c6097568036b90a2e019f9ee68c0812b2da8828be33a005a7427caf14a2b",
 					"owner": "f38daJDg8rpwL5xWgMY78fBHncQ1N5gQZ7",
 					"coins": "38.000000",
+					"src_txid": "4d080ff1f8ac21d8c09a2dca99d28ae88e9441d7a4757dca68469ad64838cb55",
 					"hours": 3846,
 					"calculated_hours": 3846
 				}
@@ -239,6 +245,7 @@
 					"uxid": "6beca9fb58a327580c614d7fb5622916849756790b661bcabc880666364fdf47",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "863600.000000",
+					"src_txid": "345488861ad3f0d93024c367990e64ef0f7a95bd8b8589f554172f9439808263",
 					"hours": 20965,
 					"calculated_hours": 3029171
 				}

--- a/src/api/integration/testdata/transaction-unconfirmed-verbose.golden
+++ b/src/api/integration/testdata/transaction-unconfirmed-verbose.golden
@@ -21,6 +21,7 @@
 				"uxid": "fe6762d753d626115c8dd3a053b5fb75d6d419a8d0fb1478c5fffc1fe41c5f20",
 				"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 				"coins": "615700.000000",
+				"src_txid": "f58f664eea258100126636a4111838e489ef5aec848ca8498319c290fa2a0805",
 				"hours": 5521648,
 				"calculated_hours": 45730107
 			}

--- a/src/api/integration/testdata/transaction-verbose-block-101.golden
+++ b/src/api/integration/testdata/transaction-verbose-block-101.golden
@@ -21,6 +21,7 @@
 				"uxid": "6002f3afc7054c0e1161bcf2b4c1d4d1009440751bc1fe806e0eae33291399f4",
 				"owner": "2M1C5LSZ4Pvu5RWS44bCdY6or3R8grQw7ez",
 				"coins": "27000.000000",
+				"src_txid": "0301358c2db5314ca43c442bac3c1daf31f4b39f9ac9e22dc157687212cab703",
 				"hours": 220,
 				"calculated_hours": 823240
 			}

--- a/src/api/integration/testdata/transaction-verbose-block-517.golden
+++ b/src/api/integration/testdata/transaction-verbose-block-517.golden
@@ -22,6 +22,7 @@
 				"uxid": "782a8662efb0e933cab7d3ae9429ab53c4208cf44d8cdc07c2fbd7204b6b5cad",
 				"owner": "2UXZTg4ZHF6715b6tRhtaqceuQQ3G79GiZg",
 				"coins": "998.000000",
+				"src_txid": "c1e3c05f9204a15e0e073f5fbcda095f2f695be5f4c42737bb6b5a5dccbec374",
 				"hours": 230999,
 				"calculated_hours": 1718944
 			},
@@ -29,6 +30,7 @@
 				"uxid": "2f6b61a44086588c4eaa56a5dd9f1e0be2528861a6731608fcec38891b95db91",
 				"owner": "2UXZTg4ZHF6715b6tRhtaqceuQQ3G79GiZg",
 				"coins": "1.000000",
+				"src_txid": "626c702534e17d3b8b72963abce25bf7aab486683ad797502dae22ecdc19a96e",
 				"hours": 259874,
 				"calculated_hours": 261364
 			}

--- a/src/api/integration/testdata/unconfirmed-excluded-from-transactions-verbose.golden
+++ b/src/api/integration/testdata/unconfirmed-excluded-from-transactions-verbose.golden
@@ -22,6 +22,7 @@
 					"uxid": "c07593d4329f82da243e4bbd7430e4b10e7b35f9ce0a3718d0e6d25d20b4939b",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "661314.000000",
+					"src_txid": "ec79854fade530d84099d5619864a8e1e8ec9d27a086917a239500cada43c6e8",
 					"hours": 0,
 					"calculated_hours": 0
 				}
@@ -65,6 +66,7 @@
 					"uxid": "bc513a68461d5c401e65a500baf7dfa163735ef63b817bb7b73c4139d5c29d18",
 					"owner": "212mwY3Dmey6vwnWpiph99zzCmopXTqeVEN",
 					"coins": "1000.000000",
+					"src_txid": "743bf1eede313145824db1c4f8d683b74ab5e0bc825082d986308b73fd52f1d7",
 					"hours": 0,
 					"calculated_hours": 561
 				}
@@ -108,6 +110,7 @@
 					"uxid": "bffea1990d71311b695b2d343b9f09a216b7a8257c1cdcb01b2ab9459e1490e3",
 					"owner": "jtuSERvfzN3kUYekg8LemCQ5kF5g97N8ZL",
 					"coins": "10.000000",
+					"src_txid": "acfb61f7ca39d5dfe33e8ed66f73ab181da0a3206d457bf055dcc4b9731a3ec8",
 					"hours": 70,
 					"calculated_hours": 70
 				}

--- a/src/api/integration/testdata/verbose-pending-transactions.golden
+++ b/src/api/integration/testdata/verbose-pending-transactions.golden
@@ -14,6 +14,7 @@
 					"uxid": "fe6762d753d626115c8dd3a053b5fb75d6d419a8d0fb1478c5fffc1fe41c5f20",
 					"owner": "R6aHqKWSQfvpdo2fGSrq4F1RYXkBWR9HHJ",
 					"coins": "615700.000000",
+					"src_txid": "f58f664eea258100126636a4111838e489ef5aec848ca8498319c290fa2a0805",
 					"hours": 5521648,
 					"calculated_hours": 45730107
 				}

--- a/src/api/transaction_test.go
+++ b/src/api/transaction_test.go
@@ -230,6 +230,10 @@ func TestGetTransactionByID(t *testing.T) {
 	validSigRaw, err := cipher.SigFromHex(validSig)
 	require.NoError(t, err)
 
+	validTxnHash := "92ad19627d26441c84a2e1faf3c7c556dfc7da754f0291af86fcfb5f0970e0db"
+	validTxnHashRaw, err := cipher.SHA256FromHex(validTxnHash)
+	require.NoError(t, err)
+
 	type httpBody struct {
 		txid    string
 		verbose string
@@ -477,9 +481,10 @@ func TestGetTransactionByID(t *testing.T) {
 					{
 						UxOut: coin.UxOut{
 							Body: coin.UxBody{
-								Coins:   9999,
-								Hours:   1111,
-								Address: validAddrRaw,
+								Coins:          9999,
+								Hours:          1111,
+								Address:        validAddrRaw,
+								SrcTransaction: validTxnHashRaw,
 							},
 						},
 						CalculatedHours: 3333,
@@ -500,9 +505,10 @@ func TestGetTransactionByID(t *testing.T) {
 						Sigs:      []string{validSig},
 						In: []readable.TransactionInput{
 							{
-								Hash:            "50e8ad459e29a051d969f221f1fb9775e26248e8b443982fef0cfaa117ee6c0c",
+								Hash:            "1f3b617258bf6c9a1901a65277d84d1a9483d26146d2c1533e4a29238e560222",
 								Coins:           "0.009999",
 								Hours:           1111,
+								SrcTxid:         validTxnHash,
 								CalculatedHours: 3333,
 								Address:         validAddr,
 							},

--- a/src/readable/transaction.go
+++ b/src/readable/transaction.go
@@ -48,6 +48,7 @@ type TransactionInput struct {
 	Hash            string `json:"uxid"`
 	Address         string `json:"owner"`
 	Coins           string `json:"coins"`
+	SrcTxid         string `json:"src_txid"`
 	Hours           uint64 `json:"hours"`
 	CalculatedHours uint64 `json:"calculated_hours"`
 }
@@ -80,6 +81,7 @@ func NewTransactionInput(input visor.TransactionInput) (TransactionInput, error)
 		Address:         input.UxOut.Body.Address.String(),
 		Coins:           coinStr,
 		Hours:           input.UxOut.Body.Hours,
+		SrcTxid:         input.UxOut.Body.SrcTransaction.Hex(),
 		CalculatedHours: input.CalculatedHours,
 	}, nil
 }


### PR DESCRIPTION
Fixes #59 

Changes:
-  Add `src_txid` to verbose transaction inputs, the following APIs will be affected:

```
/api/v1/transaction
/api/v1/transactions
/api/v1/block
/api/v1/blocks
/api/v1/pendingTxs
```

- Update unit tests and integration tests

Does this change need to mentioned in CHANGELOG.md?
Yes.