### PR TITLE
Add  wallet address scanning API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `POST /api/v1/wallet/scan` API to scan wallet addresses ahead, default scan number is `20`.
+
 ### Fixed
 
 ### Changed

--- a/run-client.sh
+++ b/run-client.sh
@@ -14,8 +14,9 @@ GOLDFLAGS="${GOLDFLAGS} -X main.Commit=${COMMIT} -X main.Branch=${BRANCH}"
 
 GORUNFLAGS=${GORUNFLAGS:-}
 
-go run -ldflags "${GOLDFLAGS}" $GORUNFLAGS cmd/skycoin/skycoin.go \
-    -gui-dir="${DIR}/src/gui/static/" \
+go install -ldflags "${GOLDFLAGS}" $GORUNFLAGS ./cmd/skycoin/...
+
+skycoin -gui-dir="${DIR}/src/gui/static/" \
     -launch-browser=true \
     -enable-all-api-sets=true \
     -enable-gui=true \

--- a/run-daemon.sh
+++ b/run-daemon.sh
@@ -14,8 +14,9 @@ GOLDFLAGS="-X main.Commit=${COMMIT} -X main.Branch=${BRANCH}"
 
 GORUNFLAGS=${GORUNFLAGS:-}
 
-go run -ldflags "${GOLDFLAGS}" $GORUNFLAGS cmd/skycoin/skycoin.go \
-    -enable-gui=false \
+go install -ldflags "${GOLDFLAGS}" $GORUNFLAGS ./cmd/skycoin/...
+
+skycoin -enable-gui=false \
     -launch-browser=false \
     -log-level=debug \
     $@

--- a/src/api/gateway.go
+++ b/src/api/gateway.go
@@ -105,6 +105,7 @@ type Walleter interface {
 	CreateWallet(wltName string, options wallet.Options, bg wallet.TransactionsFinder) (wallet.Wallet, error)
 	RecoverWallet(wltID, seed, seedPassphrase string, password []byte) (wallet.Wallet, error)
 	NewAddresses(wltID string, password []byte, n uint64) ([]cipher.Address, error)
+	ScanAddresses(wltID string, password []byte, n uint64, tf wallet.TransactionsFinder) ([]cipher.Address, error)
 	GetWallet(wltID string) (wallet.Wallet, error)
 	GetWallets() (wallet.Wallets, error)
 	UpdateWalletLabel(wltID, label string) error

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -467,6 +467,9 @@ func newServerMux(c muxConfig, gateway Gatewayer) *http.ServeMux {
 	webHandlerV1("/wallet/newAddress", walletNewAddressesHandler(gateway), map[string][]string{
 		http.MethodPost: []string{EndpointsWallet},
 	})
+	webHandlerV1("/wallet/scan", walletScanAddressesHandler(gateway), map[string][]string{
+		http.MethodPost: []string{EndpointsWallet},
+	})
 	webHandlerV1("/wallet/balance", walletBalanceHandler(gateway), map[string][]string{
 		http.MethodGet: []string{EndpointsWallet},
 	})

--- a/src/api/mock_gatewayer_test.go
+++ b/src/api/mock_gatewayer_test.go
@@ -1291,6 +1291,29 @@ func (_m *MockGatewayer) ResendUnconfirmedTxns() ([]cipher.SHA256, error) {
 	return r0, r1
 }
 
+// ScanAddresses provides a mock function with given fields: wltID, password, n, tf
+func (_m *MockGatewayer) ScanAddresses(wltID string, password []byte, n uint64, tf wallet.TransactionsFinder) ([]cipher.Address, error) {
+	ret := _m.Called(wltID, password, n, tf)
+
+	var r0 []cipher.Address
+	if rf, ok := ret.Get(0).(func(string, []byte, uint64, wallet.TransactionsFinder) []cipher.Address); ok {
+		r0 = rf(wltID, password, n, tf)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]cipher.Address)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, []byte, uint64, wallet.TransactionsFinder) error); ok {
+		r1 = rf(wltID, password, n, tf)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // StartedAt provides a mock function with given fields:
 func (_m *MockGatewayer) StartedAt() time.Time {
 	ret := _m.Called()

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -387,6 +387,66 @@ func walletNewAddressesHandler(gateway Gatewayer) http.HandlerFunc {
 	}
 }
 
+// Scan addresses to find balances
+// URI: /api/v1/wallet/scan
+// Method: POST
+// Args:
+//     id: wallet id [required]
+//     num: the number of addresses to scan ahead for balance [required, must be > 0]
+//     password: wallet password [optional, must be provided is the wallet is encrypted]
+func walletScanAddressesHandler(gateway Gatewayer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			wh.Error405(w)
+			return
+		}
+
+		wltID := r.FormValue("id")
+		if wltID == "" {
+			wh.Error400(w, "missing wallet id")
+			return
+		}
+
+		// Get the number of address to scan
+		num := r.FormValue("num")
+		var n uint64
+		if num != "" {
+			var err error
+			n, err = strconv.ParseUint(num, 10, 64)
+			if err != nil {
+				wh.Error400(w, "invalid num value")
+				return
+			}
+		}
+
+		password := r.FormValue("password")
+		defer func() {
+			password = ""
+		}()
+
+		addrs, err := gateway.ScanAddresses(wltID, []byte(password), n, gateway)
+		if err != nil {
+			switch err {
+			case wallet.ErrWalletAPIDisabled:
+				wh.Error403(w, "")
+			default:
+				wh.Error400(w, err.Error())
+			}
+			return
+		}
+
+		var rlt = struct {
+			Addresses []string `json:"addresses"`
+		}{}
+
+		for _, a := range addrs {
+			rlt.Addresses = append(rlt.Addresses, a.String())
+		}
+
+		wh.SendJSONOr500(logger, w, rlt)
+	}
+}
+
 // Update wallet label
 // URI: /api/v1/wallet/update
 // Method: POST

--- a/src/api/wallet.go
+++ b/src/api/wallet.go
@@ -392,7 +392,7 @@ func walletNewAddressesHandler(gateway Gatewayer) http.HandlerFunc {
 // Method: POST
 // Args:
 //     id: wallet id [required]
-//     num: the number of addresses to scan ahead for balance [required, must be > 0]
+//     num: the number of addresses to scan ahead for balance [optional, must be > 0, default to 20]
 //     password: wallet password [optional, must be provided is the wallet is encrypted]
 func walletScanAddressesHandler(gateway Gatewayer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -409,12 +409,16 @@ func walletScanAddressesHandler(gateway Gatewayer) http.HandlerFunc {
 
 		// Get the number of address to scan
 		num := r.FormValue("num")
-		var n uint64
+		var n uint64 = 20
 		if num != "" {
 			var err error
 			n, err = strconv.ParseUint(num, 10, 64)
 			if err != nil {
 				wh.Error400(w, "invalid num value")
+				return
+			}
+			if n <= 0 {
+				wh.Error400(w, "invalid num value, must be > 0")
 				return
 			}
 		}

--- a/src/api/wallet_test.go
+++ b/src/api/wallet_test.go
@@ -2000,7 +2000,6 @@ func TestWalletScanAddressesHandler(t *testing.T) {
 		disableCSRF                bool
 		password                   string
 		scanN                      uint64
-		tf                         wallet.TransactionsFinder
 		gatewayScanAddressesResult []cipher.Address
 		gatewayScanAddressesErr    error
 		body                       *httpBody
@@ -2021,8 +2020,6 @@ func TestWalletScanAddressesHandler(t *testing.T) {
 				Num: "1",
 			},
 			scanN: 1,
-			// gatewayScanAddressesResult: nil,
-			// gatewayScanAddressesErr:    nil,
 			expect: expect{
 				status: http.StatusBadRequest,
 				err:    "400 Bad Request - missing wallet id",

--- a/src/wallet/bip44_wallet.go
+++ b/src/wallet/bip44_wallet.go
@@ -384,12 +384,10 @@ func scanAddressesBip32(generateEntries func(num uint64, childIdx uint32) (Entri
 	}
 
 	nAddAddrs := uint64(0)
-	n := scanN
-	childIdx := initialChildIdx
 	var newEntries Entries
 
 	// Generate the addresses to scan
-	entries, err := generateEntries(n, childIdx)
+	entries, err := generateEntries(scanN, initialChildIdx)
 	if err != nil {
 		return nil, err
 	}
@@ -397,8 +395,6 @@ func scanAddressesBip32(generateEntries func(num uint64, childIdx uint32) (Entri
 	if len(entries) == 0 {
 		return nil, nil
 	}
-
-	childIdx = nextChildIdx(entries)
 
 	newEntries = append(newEntries, entries...)
 

--- a/src/wallet/deterministic_wallet.go
+++ b/src/wallet/deterministic_wallet.go
@@ -204,10 +204,9 @@ func (w *DeterministicWallet) ScanAddresses(scanN uint64, tf TransactionsFinder)
 	w2 := w.Clone().(*DeterministicWallet)
 
 	nExistingAddrs := uint64(len(w2.Entries))
-	n := scanN
 
 	// Generate the addresses to scan
-	addrs, err := w2.GenerateSkycoinAddresses(n)
+	addrs, err := w2.GenerateSkycoinAddresses(scanN)
 	if err != nil {
 		return err
 	}

--- a/src/wallet/service.go
+++ b/src/wallet/service.go
@@ -308,9 +308,64 @@ func (serv *Service) NewAddresses(wltID string, password []byte, num uint64) ([]
 	return addrs, nil
 }
 
-// func (serv *Service) ScanAddresses(wltID string, password []byte, num uint64) (Wallet, error) {
+// ScanAddresses scan ahead addresses to see if contains balance.
+func (serv *Service) ScanAddresses(wltID string, password []byte, num uint64, tf TransactionsFinder) ([]cipher.Address, error) {
+	serv.Lock()
+	defer serv.Unlock()
+	if !serv.config.EnableWalletAPI {
+		return nil, ErrWalletAPIDisabled
+	}
 
-// }
+	w, err := serv.getWallet(wltID)
+	if err != nil {
+		return nil, err
+	}
+
+	l := w.EntriesLen()
+	var addrs []cipher.Address
+	f := func(wlt Wallet) error {
+		if err := wlt.ScanAddresses(num, tf); err != nil {
+			return err
+		}
+
+		addrs, err = wlt.GetSkycoinAddresses()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if w.IsEncrypted() {
+		if err := GuardUpdate(w, password, f); err != nil {
+			return nil, err
+		}
+	} else {
+		if len(password) != 0 {
+			return nil, ErrWalletNotEncrypted
+		}
+
+		if err := f(w); err != nil {
+			return nil, err
+		}
+	}
+
+	// Checks if the wallet file is writable
+	wf := filepath.Join(serv.config.WalletDir, w.Filename())
+	if !file.IsWritable(wf) {
+		return nil, ErrWalletPermission
+	}
+
+	// Save the wallet first
+	if err := Save(w, serv.config.WalletDir); err != nil {
+		return nil, err
+	}
+
+	serv.wallets.set(w)
+
+	// return new generated addresses
+	return addrs[l:], nil
+}
 
 // GetSkycoinAddresses returns all addresses in given wallet
 func (serv *Service) GetSkycoinAddresses(wltID string) ([]cipher.Address, error) {

--- a/src/wallet/service_test.go
+++ b/src/wallet/service_test.go
@@ -2928,16 +2928,6 @@ func TestServiceScanAddresses(t *testing.T) {
 		}
 	}
 
-	// tt := []struct {
-	// 	name              string
-	// 	opts              Options
-	// 	scanN             uint64
-	// 	password          []byte
-	// 	walletAPIDisabled bool
-	// 	tf                TransactionsFinder
-	// 	expectAddrs       []cipher.Address
-	// 	expectErr         error
-	// }{}
 	for _, d := range testData {
 		tt := generateTestCasesFunc(d.walletType, d.seed, d.xpub, d.addrs)
 		for _, tc := range tt {


### PR DESCRIPTION
Fixes #200 

Changes:
- Add API endpoint `/api/v1/wallet/scan`, which will scan ahead addresses as required
- Add unit tests  for `service.ScanAddresses` function

Todo:
- [ ] Add API unit test cases
- [ ] Add integration test cases
- [ ] Update changelog

Does this change need to mentioned in CHANGELOG.md?
Yes, 