### PR TITLE
Add a missing link to the API documentation

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -53,6 +53,7 @@ The API has two versions, `/api/v1` and `/api/v2`.
 	- [Get raw transaction by id](#get-raw-transaction-by-id)
 	- [Inject raw transaction](#inject-raw-transaction)
 	- [Get transactions for addresses](#get-transactions-for-addresses)
+    - [Get transactions with pagination](#get-transactions-with-pagination)
 	- [Resend unconfirmed transactions](#resend-unconfirmed-transactions)
 	- [Verify encoded transaction](#verify-encoded-transaction)
 - [Block APIs](#block-apis)


### PR DESCRIPTION
Changes:
- A link to the `Get transactions with pagination` section was added to the API documentation.

Does this change need to mentioned in CHANGELOG.md?
No