### PR TITLE
Update osx_image to adapt the updating of electron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - TEST_SUIT=units
     - TEST_SUIT=integrations
 
-osx_image: xcode8
+osx_image: xcode11
 services: xvfb
 
 jobs:
@@ -37,12 +37,10 @@ jobs:
   - name: linux-wallet-build
     stage: build
     os: linux
-    # if: branch =~ env(BUILD_BRANCH) AND type != pull_request
     env: TEST_SUIT=""
   - name: osx-wallet-build
     stage: build
     os: osx
-    # if: branch =~ env(BUILD_BRANCH) AND type != pull_request
     env: TEST_SUIT=""
 
   - name: windows-wallet-build
@@ -51,7 +49,6 @@ jobs:
     env:
     - GOX_OUTPUT='.gox_output'
     - TEST_SUIT=""
-    # if: branch =~ env(BUILD_BRANCH) AND type != pull_request
 
 cache:
   directories:
@@ -63,12 +60,6 @@ cache:
 
 addons:
   chrome: stable
-
-# before_install:
-#   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-#     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;
-#     sudo apt-get update -qq;
-#     fi
 
 install:
   # Install gox

--- a/ci-scripts/add-key.sh
+++ b/ci-scripts/add-key.sh
@@ -18,10 +18,10 @@ echo "set keychain locking timeout to 3600"
 security set-keychain-settings -t 3600 -u $KEY_CHAIN
 
 # Add certificates to keychain and allow codesign to access them
-# security import ./electron/ci-scripts/certs/dist.cer -k $KEY_CHAIN -T /usr/bin/codesign
-# security import ./electron/ci-scripts/certs/dev.cer -k $KEY_CHAIN -T /usr/bin/codesign
 echo "import distp12"
-security import $GOPATH/src/github.com/SkycoinProject/skycoin/ci-scripts/certs/dist.p12 -k $KEY_CHAIN -P $CERT_PWD  -A /usr/bin/codesign
+security import $GOPATH/src/github.com/SkycoinProject/skycoin/ci-scripts/certs/dist.p12 -k $KEY_CHAIN -P $CERT_PWD -T /usr/bin/codesign
+
+security set-key-partition-list -S apple-tool:,apple: -s -k $OSX_KEYCHAIN_PWD $KEY_CHAIN
 
 echo "list keychains: "
 security list-keychains


### PR DESCRIPTION
Fixes #231 

Changes:
- Update `osx_image` from `xcode8` to `xcode11`
- Fix osx code signing issue that caused by the updating of osx image

Does this change need to mentioned in CHANGELOG.md?
No