### PR TITLE
Fix/improve integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ osx_image: xcode11
 services: xvfb
 
 jobs:
-  # Exclude tests for windows
+  # Exclude tests for windows and integration tests that disable-csrf and with auth
   exclude:
   - os: windows
     env: TEST_SUIT=units
@@ -66,7 +66,6 @@ cache:
   - electron/app/node_modules
   - $HOME/.cache/electron
   - $HOME/.cache/electron-builder
-  - $HOME/.npm/_prebuilds
 
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
   jobs:
     - TEST_SUIT=units
     - TEST_SUIT=integrations
+    - TEST_SUIT=integrations/disable-csrf
+    - TEST_SUIT=integrations/auth
 
 osx_image: xcode11
 services: xvfb
@@ -32,6 +34,14 @@ jobs:
     env: TEST_SUIT=units
   - os: windows
     env: TEST_SUIT=integrations
+  - os: windows
+    env: TEST_SUIT=integrations/disable-csrf
+  - os: windows
+    env: TEST_SUIT=integrations/auth
+  - os: osx
+    env: TEST_SUIT=integrations/disable-csrf
+  - os: osx
+    env: TEST_SUIT=integrations/auth
   # Build stage jobs
   include:
   - name: linux-wallet-build

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,8 @@ integration-tests-stable: integration-test-stable \
 	integration-test-stable-auth \
 	integration-test-stable-db-no-unconfirmed ## Run all stable integration tests
 
-integration-test-stable: ## Run stable integration tests
+integration-test-stable: ## Run stable integration tests use CSRF, with header check disabled
 	COIN=$(COIN) ./ci-scripts/integration-test-stable.sh -c -x -n enable-csrf-header-check
-
-integration-test-stable-disable-header-check: ## Run stable integration tests with header check disabled
-	COIN=$(COIN) ./ci-scripts/integration-test-stable.sh -n disable-header-check
 
 integration-test-stable-disable-csrf: ## Run stable integration tests with CSRF disabled
 	COIN=$(COIN) ./ci-scripts/integration-test-stable.sh -n disable-csrf

--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,10 @@ check-newcoin: newcoin ## Check that make newcoin succeeds and no templated file
 check: lint clean-coverage test test-386 integration-tests-stable check-newcoin ## Run tests and linters
 
 integration-tests-stable: integration-test-stable \
-	integration-test-stable-disable-csrf \
 	integration-test-stable-disable-wallet-api \
 	integration-test-stable-enable-seed-api \
-	integration-test-stable-disable-gui \
-	integration-test-stable-auth \
-	integration-test-stable-db-no-unconfirmed ## Run all stable integration tests
+	integration-test-stable-disable-gui ## Run all stable integration tests
+	# integration-test-stable-db-no-unconfirmed ## Run all stable integration tests
 
 integration-test-stable: ## Run stable integration tests use CSRF, with header check disabled
 	COIN=$(COIN) ./ci-scripts/integration-test-stable.sh -c -x -n enable-csrf-header-check

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,9 @@ check: lint clean-coverage test test-386 integration-tests-stable check-newcoin 
 integration-tests-stable: integration-test-stable \
 	integration-test-stable-disable-wallet-api \
 	integration-test-stable-enable-seed-api \
-	integration-test-stable-disable-gui ## Run all stable integration tests
-	# integration-test-stable-db-no-unconfirmed ## Run all stable integration tests
+	integration-test-stable-disable-gui \
+	integration-test-stable-auth \
+	integration-test-stable-disable-csrf ## Run all stable integration tests
 
 integration-test-stable: ## Run stable integration tests use CSRF, with header check disabled
 	COIN=$(COIN) ./ci-scripts/integration-test-stable.sh -c -x -n enable-csrf-header-check

--- a/ci-scripts/lint-and-test.sh
+++ b/ci-scripts/lint-and-test.sh
@@ -17,5 +17,14 @@ if [[ ${TEST_SUIT} == "units" ]]; then
 elif [[ ${TEST_SUIT} == "integrations" ]]; then
     echo "Do integration tests"
     make integration-tests-stable
+    # make integration-test-stable-disable-wallet-api
+    # make integration-test-stable-enable-seed-api
+    # make integration-test-stable-disable-gui
     make test-ui-e2e
+elif [[ ${TEST_SUIT} == "integrations/disable-csrf" ]]; then
+    echo "Do integration/disable-csrf tests"
+    make integration-test-stable-disable-csrf
+elif [[ ${TEST_SUIT} == "integrations/auth" ]]; then
+    echo "Do integration/auth tests"
+    make integration-test-stable-auth
 fi

--- a/ci-scripts/lint-and-test.sh
+++ b/ci-scripts/lint-and-test.sh
@@ -4,7 +4,6 @@ set -e -o pipefail
 
 make install-deps-ui
 make check-newcoin
-make build-ui-travis
 
 if [[ ${TEST_SUIT} == "units" ]]; then
     echo "Do unit tests"
@@ -16,11 +15,12 @@ if [[ ${TEST_SUIT} == "units" ]]; then
     make test-ui
 elif [[ ${TEST_SUIT} == "integrations" ]]; then
     echo "Do integration tests"
-    make integration-tests-stable
-    # make integration-test-stable-disable-wallet-api
-    # make integration-test-stable-enable-seed-api
-    # make integration-test-stable-disable-gui
+    make build-ui-travis
     make test-ui-e2e
+    make integration-test-stable
+    make integration-test-stable-disable-wallet-api
+    make integration-test-stable-enable-seed-api
+    make integration-test-stable-disable-gui
 elif [[ ${TEST_SUIT} == "integrations/disable-csrf" ]]; then
     echo "Do integration/disable-csrf tests"
     make integration-test-stable-disable-csrf


### PR DESCRIPTION
Changes:
- Run stable integration tests parallel for `disable-csrf` and `auth`
-  Remove `integration-test-stable-disable-hader-check`, it is not being used, and it is the same as `integration-test-stable`.
- The whole tests time reduced from 50 minutes to 20 minutes.
Does this change need to mentioned in CHANGELOG.md?
No