### PR TITLE
Update db version when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add `src_txid` to verbose transaction inputs, affected apis: `/api/v1/transaction`, `/api/v1/transactions` `/api/v1/block` `/api/v1/blocks` `/api/v1/pendingTxs`
 - Add `calculated_hours` to `/api/v1/uxout` and `/api/v1/address_uxouts`.
+- Update DB version only when DB structure is changed.
 
 ### Removed
 

--- a/src/api/http.go
+++ b/src/api/http.go
@@ -717,7 +717,7 @@ func parseSortOrderFromStr(s string) (visor.SortOrder, error) {
 	case "DESC":
 		return visor.DescOrder, nil
 	default:
-		return visor.UnknownOrder, errors.New("Unknow sort order")
+		return visor.UnknownOrder, errors.New("Unknown sort order")
 	}
 }
 

--- a/src/skycoin/db_check.go
+++ b/src/skycoin/db_check.go
@@ -99,7 +99,7 @@ func checkAndUpdateDB(db *dbutil.DB, c dbCheckConfig, dv dbCheckCorruptResetter)
 		return nil, err
 	}
 
-	action, err := checkDB(c, dbVersion)
+	action, err := checkDBVersion(c, dbVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -116,10 +116,13 @@ func checkAndUpdateDB(db *dbutil.DB, c dbCheckConfig, dv dbCheckCorruptResetter)
 			return nil, err
 		}
 		db = newDB
+	case doNothing:
+		return db, nil
 	}
 
-	if !db.IsReadOnly() {
-		if err := dv.SetDBVersion(db, c.AppVersion); err != nil {
+	// DB version won't be downgraded
+	if !db.IsReadOnly() && (dbVersion == nil || (dbVersion.LE(*c.DBCheckpointVersion))) {
+		if err := dv.SetDBVersion(db, c.DBCheckpointVersion); err != nil {
 			return nil, err
 		}
 	}
@@ -127,16 +130,16 @@ func checkAndUpdateDB(db *dbutil.DB, c dbCheckConfig, dv dbCheckCorruptResetter)
 	return db, nil
 }
 
-// checkDB checks whether need to verify or reset the DB version
-func checkDB(c dbCheckConfig, dbVersion *semver.Version) (dbAction, error) {
+// checkDBVersion checks whether need to verify or reset the DB version
+func checkDBVersion(c dbCheckConfig, dbVersion *semver.Version) (dbAction, error) {
 	// If the saved DB version is higher than the app version, abort.
 	// Otherwise DB corruption could occur.
-	if dbVersion != nil && dbVersion.GT(*c.AppVersion) {
-		return doNothing, fmt.Errorf("Cannot use newer DB version=%v with older software version=%v", dbVersion, c.AppVersion)
+	if dbVersion != nil && dbVersion.GT(*c.DBCheckpointVersion) {
+		return doNothing, fmt.Errorf("Cannot use newer DB version=%v with older check point version=%v", dbVersion, c.DBCheckpointVersion)
 	}
 
 	// Verify the DB if the version detection says to, or if it was requested on the command line
-	if shouldVerifyDB(c.AppVersion, dbVersion, c.DBCheckpointVersion) || c.ForceVerify {
+	if shouldVerifyDB(dbVersion, c.DBCheckpointVersion) || c.ForceVerify {
 		if c.ResetCorruptDB {
 			return doResetCorruptDB, nil
 		}
@@ -145,4 +148,19 @@ func checkDB(c dbCheckConfig, dbVersion *semver.Version) (dbAction, error) {
 	}
 
 	return doNothing, nil
+}
+
+func shouldVerifyDB(dbVersion, checkpointVersion *semver.Version) bool {
+	// If the dbVersion is not set, verify
+	if dbVersion == nil {
+		return true
+	}
+
+	// If the dbVersion is less than the verification checkpoint version,
+	// verify
+	if dbVersion.LT(*checkpointVersion) {
+		return true
+	}
+
+	return false
 }

--- a/src/skycoin/db_check.go
+++ b/src/skycoin/db_check.go
@@ -25,8 +25,8 @@ type dbCheckConfig struct {
 	ForceVerify bool
 	// ResetCorruptDB reset the DB if it is corrupted
 	ResetCorruptDB bool
-	// AppVersion is the current wallet version
-	AppVersion *semver.Version
+	// // AppVersion is the current wallet version
+	// AppVersion *semver.Version
 	// DBCheckpointVersion is the check point db version
 	DBCheckpointVersion *semver.Version
 }

--- a/src/skycoin/db_check_test.go
+++ b/src/skycoin/db_check_test.go
@@ -35,67 +35,55 @@ func TestCheckDB(t *testing.T) {
 	}{
 		{
 			name:      "do nothing",
-			params:    dbCheckConfig{AppVersion: v26, DBCheckpointVersion: v25},
-			dbVersion: v26,
+			params:    dbCheckConfig{DBCheckpointVersion: v25},
+			dbVersion: v25,
 			exp:       expect{action: doNothing},
 		},
 		{
 			name:   "db version nil, check db",
-			params: dbCheckConfig{AppVersion: v26},
+			params: dbCheckConfig{DBCheckpointVersion: v25},
 			exp:    expect{action: doCheckDB},
 		},
 		{
 			name:   "db version nil, reset corrupt db",
-			params: dbCheckConfig{AppVersion: v26, ResetCorruptDB: true, DBCheckpointVersion: v25},
+			params: dbCheckConfig{ResetCorruptDB: true, DBCheckpointVersion: v25},
 			exp:    expect{action: doResetCorruptDB},
 		},
 		{
-			name:      "db version > app version get err",
-			params:    dbCheckConfig{AppVersion: v241, DBCheckpointVersion: v25},
-			dbVersion: v25,
-			exp:       expect{action: doNothing, err: errors.New("Cannot use newer DB version=0.25.0 with older software version=0.24.1")},
-		},
-		{
-			name:      "db version < check point < app version, check DB",
-			params:    dbCheckConfig{AppVersion: v26, DBCheckpointVersion: v25},
-			dbVersion: v241,
-			exp:       expect{action: doCheckDB},
-		},
-		{
-			name:      "db version < check point < app version, reset corrupt db",
-			params:    dbCheckConfig{AppVersion: v26, ResetCorruptDB: true, DBCheckpointVersion: v25},
-			dbVersion: v241,
-			exp:       expect{action: doResetCorruptDB},
-		},
-		{
-			name:      "db version < check point == app version, check DB",
-			params:    dbCheckConfig{AppVersion: v25, DBCheckpointVersion: v25},
-			dbVersion: v241,
-			exp:       expect{action: doCheckDB},
-		},
-		{
-			name:      "db version < check point == app version, reset corrupt DB",
-			params:    dbCheckConfig{AppVersion: v25, ResetCorruptDB: true, DBCheckpointVersion: v25},
-			dbVersion: v241,
-			exp:       expect{action: doResetCorruptDB},
-		},
-		{
-			name:      "db version == app version, force verify, check DB",
-			params:    dbCheckConfig{AppVersion: v26, ForceVerify: true, DBCheckpointVersion: v25},
+			name:      "db version > check point, get err",
+			params:    dbCheckConfig{DBCheckpointVersion: v25},
 			dbVersion: v26,
+			exp:       expect{action: doNothing, err: errors.New("Cannot use newer DB version=0.26.0 with older check point version=0.25.0")},
+		},
+		{
+			name:      "db version < check point, check DB",
+			params:    dbCheckConfig{DBCheckpointVersion: v25},
+			dbVersion: v241,
+			exp:       expect{action: doCheckDB},
+		},
+		{
+			name:      "db version < check point, reset corrupt db",
+			params:    dbCheckConfig{ResetCorruptDB: true, DBCheckpointVersion: v25},
+			dbVersion: v241,
+			exp:       expect{action: doResetCorruptDB},
+		},
+		{
+			name:      "db version == check point, force verify, check DB",
+			params:    dbCheckConfig{ForceVerify: true, DBCheckpointVersion: v25},
+			dbVersion: v25,
 			exp:       expect{action: doCheckDB},
 		},
 		{
 			name:      "db version == app version, force verify, reset corrupt DB",
-			params:    dbCheckConfig{AppVersion: v26, ForceVerify: true, ResetCorruptDB: true, DBCheckpointVersion: v25},
-			dbVersion: v26,
+			params:    dbCheckConfig{ForceVerify: true, ResetCorruptDB: true, DBCheckpointVersion: v25},
+			dbVersion: v25,
 			exp:       expect{action: doResetCorruptDB},
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			action, err := checkDB(tc.params, tc.dbVersion)
+			action, err := checkDBVersion(tc.params, tc.dbVersion)
 			require.Equal(t, tc.exp.action, action)
 			require.Equal(t, tc.exp.err, err)
 		})
@@ -141,99 +129,85 @@ func TestCheckAndUpdateDB(t *testing.T) {
 	}{
 		{
 			name:         "do nothing",
-			config:       dbCheckConfig{AppVersion: v26, DBCheckpointVersion: v25},
+			config:       dbCheckConfig{DBCheckpointVersion: v26},
 			db:           db,
 			dbVersion:    v26,
 			setDBVersion: v26,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
 				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
+				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v26))
 			},
 		},
 		{
 			name:         "db version nil - check db",
-			config:       dbCheckConfig{AppVersion: v26, DBCheckpointVersion: v25},
+			config:       dbCheckConfig{DBCheckpointVersion: v25},
 			db:           db,
 			dbVersion:    nil,
-			setDBVersion: v26,
+			setDBVersion: v25,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
+				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
 			},
 		},
 		{
 			name:         "db version nil - reset corrupt db",
-			config:       dbCheckConfig{AppVersion: v26, ResetCorruptDB: true, DBCheckpointVersion: v25},
+			config:       dbCheckConfig{ResetCorruptDB: true, DBCheckpointVersion: v25},
 			db:           db,
 			dbVersion:    nil,
-			setDBVersion: v26,
+			setDBVersion: v25,
 			resetedDB:    resetedDB,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
 				require.True(t, m.AssertCalled(t, "ResetCorruptDB", matchFunc))
+				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
 			},
 		},
 		{
-			name: "db version > app version get err",
-			config: dbCheckConfig{
-				AppVersion:          v241,
-				DBCheckpointVersion: v25,
-			},
+			name:      "db version > check point get err",
+			config:    dbCheckConfig{DBCheckpointVersion: v25},
 			db:        db,
-			dbVersion: v25,
-			retErr:    errors.New("Cannot use newer DB version=0.25.0 with older software version=0.24.1"),
+			dbVersion: v26,
+			retErr:    errors.New("Cannot use newer DB version=0.26.0 with older check point version=0.25.0"),
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v26))
+				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v25))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
 			},
 		},
 		{
-			name: "db version < check point < app version - check db",
-			config: dbCheckConfig{
-				AppVersion:          v26,
-				DBCheckpointVersion: v25,
-			},
+			name:         "db version < check point - check db",
+			config:       dbCheckConfig{DBCheckpointVersion: v25},
 			db:           db,
 			dbVersion:    v241,
-			checkDBErr:   nil,
-			setDBVersion: v26,
+			setDBVersion: v25,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
+				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
 			},
 		},
 		{
-			name: "db version < check point < app version - check db - read only db",
-			config: dbCheckConfig{
-				AppVersion:          v26,
-				DBCheckpointVersion: v25,
-			},
-			db:         readOnlyDB,
-			dbVersion:  v241,
-			checkDBErr: nil,
+			name:      "db version < check point - check db - read only db",
+			config:    dbCheckConfig{DBCheckpointVersion: v25},
+			db:        readOnlyDB,
+			dbVersion: v241,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v26))
+				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v25))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
 			},
 		},
 		{
-			name: "db version < check point < app version - check db - got err",
-			config: dbCheckConfig{
-				AppVersion:          v26,
-				DBCheckpointVersion: v25,
-			},
+			name:       "db version < check point - check db - got err",
+			config:     dbCheckConfig{DBCheckpointVersion: v25},
 			db:         db,
 			dbVersion:  v241,
 			checkDBErr: errors.New("check db error"),
@@ -241,35 +215,27 @@ func TestCheckAndUpdateDB(t *testing.T) {
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v26))
+				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v25))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
 			},
 		},
 		{
-			name: "db version < check point < app version - reset corrupt db",
-			config: dbCheckConfig{
-				AppVersion:          v26,
-				DBCheckpointVersion: v25,
-				ResetCorruptDB:      true,
-			},
+			name:         "db version < check point - reset corrupt db",
+			config:       dbCheckConfig{DBCheckpointVersion: v25, ResetCorruptDB: true},
 			db:           db,
 			dbVersion:    v241,
 			resetedDB:    resetedDB,
-			setDBVersion: v26,
+			setDBVersion: v25,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
 				require.True(t, m.AssertCalled(t, "ResetCorruptDB", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
+				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
 			},
 		},
 		{
-			name: "db version < check point < app version - reset corrupt db - got err",
-			config: dbCheckConfig{
-				AppVersion:          v26,
-				DBCheckpointVersion: v25,
-				ResetCorruptDB:      true,
-			},
+			name:       "db version < check point - reset corrupt db - got err",
+			config:     dbCheckConfig{DBCheckpointVersion: v25, ResetCorruptDB: true},
 			db:         db,
 			dbVersion:  v241,
 			resetDBErr: errors.New("reset corrupt db failed"),
@@ -278,77 +244,41 @@ func TestCheckAndUpdateDB(t *testing.T) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
 				require.True(t, m.AssertCalled(t, "ResetCorruptDB", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v26))
+				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v25))
 			},
 		},
 		{
-			name: "db version < check point == app version - check DB",
+			name: "db version == check point - force verify - check DB",
 			config: dbCheckConfig{
-				AppVersion:          v25,
-				DBCheckpointVersion: v25,
-			},
-			db:           db,
-			dbVersion:    v241,
-			setDBVersion: v25,
-			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
-				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
-				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
-			},
-		},
-		{
-			name: "db version < check point == app version - reset DB",
-			config: dbCheckConfig{
-				AppVersion:          v25,
-				DBCheckpointVersion: v25,
-				ResetCorruptDB:      true,
-			},
-			db:           db,
-			dbVersion:    v241,
-			setDBVersion: v25,
-			resetedDB:    resetedDB,
-			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
-				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertCalled(t, "ResetCorruptDB", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
-			},
-		},
-		{
-			name: "db version == app version - force verify - check DB",
-			config: dbCheckConfig{
-				AppVersion:          v26,
 				DBCheckpointVersion: v25,
 				ForceVerify:         true,
 			},
 			db:           db,
-			dbVersion:    v26,
-			setDBVersion: v26,
+			dbVersion:    v25,
+			setDBVersion: v25,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
+				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
 			},
 		},
 		{
 			name: "db version == app version - force verify - reset corrupt DB",
 			config: dbCheckConfig{
-				AppVersion:          v26,
 				DBCheckpointVersion: v25,
 				ForceVerify:         true,
 				ResetCorruptDB:      true,
 			},
 			db:           db,
-			dbVersion:    v26,
-			setDBVersion: v26,
+			dbVersion:    v25,
+			setDBVersion: v25,
 			resetedDB:    resetedDB,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
 				require.True(t, m.AssertCalled(t, "ResetCorruptDB", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
+				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
 			},
 		},
 	}

--- a/src/skycoin/db_check_test.go
+++ b/src/skycoin/db_check_test.go
@@ -18,9 +18,6 @@ func TestCheckDB(t *testing.T) {
 		err    error
 	}
 
-	v241, err := semver.New("0.24.1")
-	require.NoError(t, err)
-
 	v25, err := semver.New("0.25.0")
 	require.NoError(t, err)
 
@@ -57,14 +54,14 @@ func TestCheckDB(t *testing.T) {
 		},
 		{
 			name:      "db version < check point, check DB",
-			params:    dbCheckConfig{DBCheckpointVersion: v25},
-			dbVersion: v241,
+			params:    dbCheckConfig{DBCheckpointVersion: v26},
+			dbVersion: v25,
 			exp:       expect{action: doCheckDB},
 		},
 		{
 			name:      "db version < check point, reset corrupt db",
-			params:    dbCheckConfig{ResetCorruptDB: true, DBCheckpointVersion: v25},
-			dbVersion: v241,
+			params:    dbCheckConfig{ResetCorruptDB: true, DBCheckpointVersion: v26},
+			dbVersion: v25,
 			exp:       expect{action: doResetCorruptDB},
 		},
 		{
@@ -91,9 +88,6 @@ func TestCheckDB(t *testing.T) {
 }
 
 func TestCheckAndUpdateDB(t *testing.T) {
-	v241, err := semver.New("0.24.1")
-	require.NoError(t, err)
-
 	v25, err := semver.New("0.25.0")
 	require.NoError(t, err)
 
@@ -182,69 +176,69 @@ func TestCheckAndUpdateDB(t *testing.T) {
 		},
 		{
 			name:         "db version < check point - check db",
-			config:       dbCheckConfig{DBCheckpointVersion: v25},
+			config:       dbCheckConfig{DBCheckpointVersion: v26},
 			db:           db,
-			dbVersion:    v241,
-			setDBVersion: v25,
+			dbVersion:    v25,
+			setDBVersion: v26,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
+				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
 			},
 		},
 		{
 			name:      "db version < check point - check db - read only db",
-			config:    dbCheckConfig{DBCheckpointVersion: v25},
+			config:    dbCheckConfig{DBCheckpointVersion: v26},
 			db:        readOnlyDB,
-			dbVersion: v241,
+			dbVersion: v25,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v25))
+				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v26))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
 			},
 		},
 		{
 			name:       "db version < check point - check db - got err",
-			config:     dbCheckConfig{DBCheckpointVersion: v25},
+			config:     dbCheckConfig{DBCheckpointVersion: v26},
 			db:         db,
-			dbVersion:  v241,
+			dbVersion:  v25,
 			checkDBErr: errors.New("check db error"),
 			retErr:     errors.New("check db error"),
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertCalled(t, "CheckDatabase", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v25))
+				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v26))
 				require.True(t, m.AssertNotCalled(t, "ResetCorruptDB", matchFunc))
 			},
 		},
 		{
 			name:         "db version < check point - reset corrupt db",
-			config:       dbCheckConfig{DBCheckpointVersion: v25, ResetCorruptDB: true},
+			config:       dbCheckConfig{DBCheckpointVersion: v26, ResetCorruptDB: true},
 			db:           db,
-			dbVersion:    v241,
+			dbVersion:    v25,
 			resetedDB:    resetedDB,
-			setDBVersion: v25,
+			setDBVersion: v26,
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
 				require.True(t, m.AssertCalled(t, "ResetCorruptDB", matchFunc))
-				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v25))
+				require.True(t, m.AssertCalled(t, "SetDBVersion", matchFunc, v26))
 			},
 		},
 		{
 			name:       "db version < check point - reset corrupt db - got err",
-			config:     dbCheckConfig{DBCheckpointVersion: v25, ResetCorruptDB: true},
+			config:     dbCheckConfig{DBCheckpointVersion: v26, ResetCorruptDB: true},
 			db:         db,
-			dbVersion:  v241,
+			dbVersion:  v25,
 			resetDBErr: errors.New("reset corrupt db failed"),
 			retErr:     errors.New("reset corrupt db failed"),
 			assertCalled: func(t *testing.T, db *dbutil.DB, m *mockDbCheckCorruptResetter) {
 				require.True(t, m.AssertCalled(t, "GetDBVersion", matchFunc))
 				require.True(t, m.AssertNotCalled(t, "CheckDatabase", matchFunc))
 				require.True(t, m.AssertCalled(t, "ResetCorruptDB", matchFunc))
-				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v25))
+				require.True(t, m.AssertNotCalled(t, "SetDBVersion", matchFunc, v26))
 			},
 		},
 		{

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -174,7 +174,6 @@ func (c *Coin) Run() error {
 	cf := dbCheckConfig{
 		ForceVerify:         c.config.Node.VerifyDB,
 		ResetCorruptDB:      c.config.Node.ResetCorruptDB,
-		AppVersion:          appVersion,
 		DBCheckpointVersion: &dbVerifyCheckpointVersionParsed,
 	}
 

--- a/src/skycoin/skycoin.go
+++ b/src/skycoin/skycoin.go
@@ -39,7 +39,7 @@ var (
 	// DBVerifyCheckpointVersion is a checkpoint for determining if DB verification should be run.
 	// Any DB upgrading from less than this version to equal or higher than this version will be forced to verify.
 	// Update this version checkpoint if a newer version requires a new verification run.
-	DBVerifyCheckpointVersion       = "0.25.0"
+	DBVerifyCheckpointVersion       = "0.27.0"
 	dbVerifyCheckpointVersionParsed semver.Version
 )
 
@@ -608,22 +608,6 @@ func createDirIfNotExist(dir string) error {
 	}
 
 	return os.Mkdir(dir, 0750)
-}
-
-func shouldVerifyDB(appVersion, dbVersion, checkpointVersion *semver.Version) bool {
-	// If the dbVersion is not set, verify
-	if dbVersion == nil {
-		return true
-	}
-
-	// If the dbVersion is less than the verification checkpoint version
-	// and the appVersion is greater than or equal to the checkpoint version,
-	// verify
-	if dbVersion.LT(*checkpointVersion) && appVersion.GTE(*checkpointVersion) {
-		return true
-	}
-
-	return false
 }
 
 func init() {

--- a/src/visor/transaction_model.go
+++ b/src/visor/transaction_model.go
@@ -164,7 +164,7 @@ func (s *txnHashesContainer) Sort(order SortOrder) error {
 			return lessFunc(j, i)
 		})
 	default:
-		return errors.New("unknow sort order")
+		return errors.New("unknown sort order")
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #229 

Changes:
- Update check point to v0.27.0
- Do not update DB version unless the DB structure is changed. 
- Remove the App version from the DB version verify logic. We only need to check if the DB version is equal to the check point. If the DB version is less than the check point, check the DB reset if needed. If the DB version is equal to the check point, then we don't need to check the DB. If the DB version is greater than the  check point, return error.
- Update changelog.


Does this change need to mentioned in CHANGELOG.md?
Yes, Updated.