### PR TITLE
Use bucket.Cursor().First() to check if bucket is empty

### DIFF
--- a/src/visor/dbutil/dbutil.go
+++ b/src/visor/dbutil/dbutil.go
@@ -325,11 +325,14 @@ func Len(tx *Tx, bktName []byte) (uint64, error) {
 
 // IsEmpty returns true if the bucket is empty
 func IsEmpty(tx *Tx, bktName []byte) (bool, error) {
-	length, err := Len(tx, bktName)
-	if err != nil {
-		return false, err
+	b := tx.Bucket(bktName)
+	if b == nil {
+		return false, NewErrBucketNotExist(bktName)
 	}
-	return length == 0, nil
+
+	c := b.Cursor()
+	k, _ := c.First()
+	return k == nil, nil
 }
 
 // Exists returns true if the bucket exists


### PR DESCRIPTION
Fixes #54 

Changes:
- Use `bucket.Cursor().First()` to check if the bucket is empty. 

Does this change need to mentioned in CHANGELOG.md?
No.