### PR TITLE
Check defer file.Close() error on writeable file

### DIFF
--- a/src/cli/address_gen.go
+++ b/src/cli/address_gen.go
@@ -291,20 +291,13 @@ func fiberAddressGenCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer func() {
-				cErr := addrsF.Close()
-				if cErr != nil {
-					err = cErr
-				}
-			}()
+			defer addrsF.Close()
 
 			seedsF, err := os.Create(seedsFilename)
-			defer func() {
-				cErr := seedsF.Close()
-				if cErr != nil {
-					err = cErr
-				}
-			}()
+			if err != nil {
+				return err
+			}
+			defer seedsF.Close()
 
 			for i, a := range addrs {
 				if _, err := fmt.Fprintf(addrsF, "\"%s\",\n", a); err != nil {
@@ -315,7 +308,11 @@ func fiberAddressGenCmd() *cobra.Command {
 				}
 			}
 
-			return nil
+			if err := addrsF.Sync(); err != nil {
+				return err
+			}
+
+			return seedsF.Close()
 		},
 	}
 

--- a/src/cli/address_gen.go
+++ b/src/cli/address_gen.go
@@ -312,7 +312,7 @@ func fiberAddressGenCmd() *cobra.Command {
 				return err
 			}
 
-			return seedsF.Close()
+			return seedsF.Sync()
 		},
 	}
 

--- a/src/util/file/file.go
+++ b/src/util/file/file.go
@@ -146,8 +146,9 @@ func SaveJSONSafe(filename string, thing interface{}, mode os.FileMode) error {
 		if removeErr := os.Remove(filename); removeErr != nil {
 			logger.WithError(removeErr).Warningf("os.Remove(%s) failed", filename)
 		}
+		return err
 	}
-	return err
+	return f.Sync()
 }
 
 // SaveBinary persists data into given file in binary,


### PR DESCRIPTION
Fixes #88 

Changes:
- Call `file.Sync()` to flush the data on buffer if any before closing file. 

Does this change need to mentioned in CHANGELOG.md?
No.