### PR TITLE
Allow to save the addresses of a wallet as a CSV file

### DIFF
--- a/src/gui/static/src/app/components/pages/settings/backup/backup.component.html
+++ b/src/gui/static/src/app/components/pages/settings/backup/backup.component.html
@@ -14,22 +14,29 @@
     <app-loading-content
       [isLoading]="false"
       noDataText="backup.no-wallets"
-      *ngIf="onlyEncrypted.length === 0"
+      *ngIf="wallets.length === 0"
     ></app-loading-content>
 
     <!-- Wallet list. -->
-    <div class="-table" *ngIf="onlyEncrypted.length > 0">
+    <div class="-table" *ngIf="wallets.length > 0">
       <div class="-headers">
         <div class="-width-250">{{ 'backup.wallet-table-label' | translate }}</div>
         <div class="-width-150">{{ 'backup.filename-table-label' | translate }}</div>
         <div class="-flex-fill"></div>
       </div>
       <div class="-body">
-        <div class="-row" *ngFor="let wallet of onlyEncrypted">
+        <div class="-row" *ngFor="let wallet of wallets">
           <div class="-width-250 text-truncate" [attr.title]="wallet.label">{{ wallet.label }}</div>
           <div class="-width-150">{{ wallet.id }}</div>
+          <!-- Buttons. -->
           <div class="-flex-fill text-right">
-            <span class="link" (click)="showSeed(wallet)">{{ 'backup.show-seed-button' | translate }}</span>
+            <div class="link address-link" (click)="saveAddresses(wallet)">{{ 'backup.save-addresses-button' | translate }}</div>
+            <div class="link" (click)="showSeed(wallet)" *ngIf="wallet.encrypted && !wallet.isHardware">{{ 'backup.show-seed-button' | translate }}</div>
+            <div *ngIf="!wallet.encrypted || wallet.isHardware">
+              <mat-icon *ngIf="!wallet.encrypted && !wallet.isHardware" class="help-icon" [matTooltip]="'backup.unencrypted-info' | translate">help</mat-icon>
+              <mat-icon *ngIf="wallet.isHardware" class="help-icon" [matTooltip]="'backup.hw-wallet-info' | translate">help</mat-icon>
+              {{ 'backup.show-seed-button' | translate }}
+            </div>
           </div>
         </div>
       </div>

--- a/src/gui/static/src/app/components/pages/settings/backup/backup.component.scss
+++ b/src/gui/static/src/app/components/pages/settings/backup/backup.component.scss
@@ -1,0 +1,3 @@
+.address-link {
+  margin-bottom: 2px;
+}

--- a/src/gui/static/src/app/components/pages/settings/backup/backup.component.ts
+++ b/src/gui/static/src/app/components/pages/settings/backup/backup.component.ts
@@ -56,7 +56,7 @@ export class BackupComponent implements OnInit, OnDestroy {
     // Create the address list.
     let addresses = '';
     wallet.addresses.forEach(address => {
-      addresses += address.address + ',';
+      addresses += address.address + '\n';
     });
     addresses = addresses.substr(0, addresses.length - 1);
 

--- a/src/gui/static/src/app/components/pages/settings/backup/backup.component.ts
+++ b/src/gui/static/src/app/components/pages/settings/backup/backup.component.ts
@@ -51,8 +51,30 @@ export class BackupComponent implements OnInit, OnDestroy {
     this.walletSubscription.unsubscribe();
   }
 
-  get onlyEncrypted() {
-    return this.wallets.filter(wallet => wallet.encrypted && !wallet.isHardware);
+  // Creates a csv file with the addresses and makes the browser download it.
+  saveAddresses(wallet: WalletBase) {
+    // Create the address list.
+    let addresses = '';
+    wallet.addresses.forEach(address => {
+      addresses += address.address + ',';
+    });
+    addresses = addresses.substr(0, addresses.length - 1);
+
+
+    // Create an invisible link and click it to download the data.
+    const blob = new Blob([addresses], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    if (link.download !== undefined) {
+      const url = URL.createObjectURL(blob);
+      link.setAttribute('href', url);
+      link.setAttribute('download', wallet.label + '.csv');
+      link.style.visibility = 'hidden';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else {
+      this.msgBarService.showError('backup.not-compatible-error');
+    }
   }
 
   showSeed(wallet: WalletBase) {

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -346,8 +346,12 @@
     "desc": "Use the table below to get seeds from your encrypted wallets. <br>To get seeds from unencrypted wallets, open the folder above, open the .wlt files in a text editor and recover the seeds.",
     "wallet-table-label": "Wallet name",
     "filename-table-label": "Filename",
+    "save-addresses-button": "Save Addresses",
     "show-seed-button": "Show Seed",
-    "no-wallets": "No encrypted wallets",
+    "no-wallets": "There are no wallets",
+    "unencrypted-info": "For security reasons, it is not possible to show the seeds of unencrypted wallets. To get the seed, please encrypt the wallet with a password or follow the instruction shown at the top of this page.",
+    "hw-wallet-info": "For getting the seed of a Skywallet, please use the \"Skywallet\" option at the bottom of the wallets page.",
+    "not-compatible-error": "Your web browser is not compatible with this function.",
 
     "seed-modal-window": {
       "title": "Wallet Seed",

--- a/src/gui/static/src/assets/i18n/es.json
+++ b/src/gui/static/src/assets/i18n/es.json
@@ -350,8 +350,12 @@
     "desc": "Use la tabla de más abajo para obtener las semillas de sus billeteras encriptadas. <br>Para obtener las semillas de las billeteras no encriptadas, abra el directorio de más arriba, abra los archivos .wlt en un editor de texto y recupere las semillas.",
     "wallet-table-label": "Nombre de la billetera",
     "filename-table-label": "Archivo",
+    "save-addresses-button": "Guardar Direcciones",
     "show-seed-button": "Mostrar semilla",
-    "no-wallets": "No hay billeteras encriptadas",
+    "no-wallets": "No hay billeteras",
+    "unencrypted-info": "Por razones de seguridad, no es posible mostrar las semillas de las billeteras sin encriptar. Para obtener la semilla, por favor encripte la billetera con una contraseña o siga las instrucciones en la parte superior de esta página.",
+    "hw-wallet-info": "Para obtener la semilla de una Skywallet, por favor use la opción \"Skywallet\" de la parte inferior de la página de billeteras.",
+    "not-compatible-error": "Su navegador web no es compatible con esta función.",
 
     "seed-modal-window": {
       "title": "Semilla de la Billetera",

--- a/src/gui/static/src/assets/i18n/es_base.json
+++ b/src/gui/static/src/assets/i18n/es_base.json
@@ -350,8 +350,12 @@
     "desc": "Use the table below to get seeds from your encrypted wallets. <br>To get seeds from unencrypted wallets, open the folder above, open the .wlt files in a text editor and recover the seeds.",
     "wallet-table-label": "Wallet name",
     "filename-table-label": "Filename",
+    "save-addresses-button": "Save Addresses",
     "show-seed-button": "Show Seed",
-    "no-wallets": "No encrypted wallets",
+    "no-wallets": "There are no wallets",
+    "unencrypted-info": "For security reasons, it is not possible to show the seeds of unencrypted wallets. To get the seed, please encrypt the wallet with a password or follow the instruction shown at the top of this page.",
+    "hw-wallet-info": "For getting the seed of a Skywallet, please use the \"Skywallet\" option at the bottom of the wallets page.",
+    "not-compatible-error": "Your web browser is not compatible with this function.",
 
     "seed-modal-window": {
       "title": "Wallet Seed",


### PR DESCRIPTION
Fixes #269

Changes:
- The page for creating wallet backups now has a link for making the browser download a csv file with all the addresses of the wallets.
- Now the page for creating wallet backups shows all the wallets and not just the encrypted ones, as it is possible to create csv files for all wallets. If a wallet is not encrypted, the option for checking the seed is not active and the user can see a help msg.

Does this change need to mentioned in CHANGELOG.md?
No