### PR TITLE
Improved error messages in the UI

### DIFF
--- a/src/gui/static/src/app/utils/errors.ts
+++ b/src/gui/static/src/app/utils/errors.ts
@@ -13,6 +13,12 @@ export function processErrorMsg(msg: string): string {
     return msg;
   }
 
+  // Check if the string is from a known error. If it is, use the correct error string.
+  const knownErrorMsg = checkIfKnownErrorStrings(msg);
+  if (knownErrorMsg) {
+    return knownErrorMsg;
+  }
+
   // Some times an error message could be in fact a JSON string. In those cases, the real
   // error msg is inside the "error.message" property.
   if (msg.indexOf('"error":') !== -1) {
@@ -141,4 +147,52 @@ export function getErrorMsg(error: any): string {
  */
 export function redirectToErrorPage(errorCode: number) {
   window.location.assign('assets/error-alert/index.html?' + errorCode);
+}
+
+/**
+ * Checks if a string contains a known error msg.
+ * @param errorString String to check.
+ * @returns If the string is known, the translatable var for showing the error in the UI. If
+ * not, null is returned.
+ */
+function checkIfKnownErrorStrings(errorString: string): string {
+  errorString = errorString.toUpperCase();
+
+  let translatableVar: string = null;
+
+  if (errorString.includes('CHANGEADDRESS MUST NOT BE THE NULL ADDRESS')) {
+    translatableVar = 'null-change-address-error';
+  } else if (errorString.includes('TO IS REQUIRED')) {
+    translatableVar = 'to-required-error';
+  } else if (errorString.includes('TO.COINS MUST NOT BE ZERO')) {
+    translatableVar = 'zero-coins-error';
+  } else if (errorString.includes('TO.ADDRESS MUST NOT BE THE NULL ADDRESS')) {
+    translatableVar = 'null-destination-error';
+  } else if (errorString.includes('TO CONTAINS DUPLICATE VALUES')) {
+    translatableVar = 'duplicate-destination-error';
+  } else if (errorString.includes('TO.HOURS MUST BE ZERO FOR AUTO TYPE HOURS SELECTION')) {
+    translatableVar = 'hours-in-automatic-mode-error';
+  } else if (errorString.includes('HOURSSELECTION.MODE IS REQUIRED FOR AUTO TYPE HOURS SELECTION')) {
+    translatableVar = 'hours-allocation-mode-needed-error';
+  } else if (errorString.includes('INVALID HOURSSELECTION.MODE')) {
+    translatableVar = 'invalid-hours-allocation-mode-error';
+  } else if (errorString.includes('HOURSSELECTION.MODE CANNOT BE USED FOR MANUAL TYPE HOURS SELECTION')) {
+    translatableVar = 'hours-allocation-mode-not-needed-error';
+  } else if (errorString.includes('INVALID HOURSSELECTION.TYPE')) {
+    translatableVar = 'invalid-hours-mode-error';
+  } else if (errorString.includes('HOURSSELECTION.SHAREFACTOR MUST BE SET FOR SHARE MODE')) {
+    translatableVar = 'share-factor-needed-error';
+  } else if (errorString.includes('HOURSSELECTION.SHAREFACTOR CAN ONLY BE USED FOR SHARE MODE')) {
+    translatableVar = 'share-factor-not-needed-error';
+  } else if (errorString.includes('HOURSSELECTION.SHAREFACTOR MUST BE >= 0 AND <= 1')) {
+    translatableVar = 'invalid-share-factor-error';
+  } else if (errorString.includes('TRANSACTION VIOLATES HARD CONSTRAINT: DUPLICATE OUTPUT IN TRANSACTION')) {
+    translatableVar = 'change-equal-to-destination-error';
+  }
+
+  if (translatableVar) {
+    return 'send.known-node-errors.' + translatableVar;
+  }
+
+  return null;
 }

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -259,6 +259,23 @@
     "sending-all-hours-waning": "You selected to send all the hours. Are you sure you want to continue?",
     "high-hours-share-waning": "Your selection may result in sending all the hours in the wallet. Are you sure you want to continue?",
 
+    "known-node-errors": {
+      "null-change-address-error": "The null address can't be used as the custom change address. Please enter a valid address.",
+      "to-required-error": "You must provide a destination address for sending coins. Please enter a valid address.",
+      "zero-coins-error": "It's not possible to send zero coins. Please enter a valid amount.",
+      "null-destination-error": "The null address can't be used as destination. Please enter a valid address.",
+      "duplicate-destination-error": "There are duplicate destinations. Please do not repeat the same address and amount in more than one destination.",
+      "hours-in-automatic-mode-error": "Specific hour amounts can't be specified while using automatic hour distribution. Please try with different values and contact support if the problem is not solved.",
+      "hours-allocation-mode-needed-error": "The hour allocation mode is required. Please try with different values and contact support if the problem is not solved.",
+      "invalid-hours-allocation-mode-error": "Invalid hour allocation mode. Please try with different values and contact support if the problem is not solved.",
+      "hours-allocation-mode-not-needed-error": "The hour allocation mode can't be specified while using manual hour distribution. Please try with different values and contact support if the problem is not solved.",
+      "invalid-hours-mode-error": "Invalid hour distribution method. Please try with different values and contact support if the problem is not solved.",
+      "share-factor-needed-error": "The hours share factor is needed. Please try with different values and contact support if the problem is not solved.",
+      "share-factor-not-needed-error": "The hours share factor can't be specified while using manual hour distribution. Please try with different values and contact support if the problem is not solved.",
+      "invalid-share-factor-error": "Invalid share factor. Please try with different values and contact support if the problem is not solved.",
+      "change-equal-to-destination-error": "The transaction can't be created because a repeated amount of coins would be returned to the same destination address. Please try again with different values."
+    },
+
     "bulk-send": {
       "title": "Bulk Send",
       "indications": "To send to multiple destinations in a quick way, type each address, coin amount and hour amount (optional) on a line, separated by a comma. Example: if you want to send 10 coins and 5 hours to the \"xyz\" address, type \"xyz,10,5\"; if you want the hours to be calculated automatically, type \"xyz,10\". Decimal values must be separated with a dot.",

--- a/src/gui/static/src/assets/i18n/es.json
+++ b/src/gui/static/src/assets/i18n/es.json
@@ -261,6 +261,23 @@
     "sending-all-hours-waning": "Usted seleccionó enviar todas las horas. ¿Seguro que desea continuar?",
     "high-hours-share-waning": "Su selección puede resultar en el envío de todas las horas de la billetera. ¿Seguro que desea continuar?",
 
+    "known-node-errors": {
+      "null-change-address-error": "La dirección nula no se puede utilizar como dirección de retorno personalizada. Por favor introduzca una dirección válida.",
+      "to-required-error": "Debe proporcionar una dirección de destino para enviar monedas. Por favor introduzca una dirección válida.",
+      "zero-coins-error": "No es posible enviar cero monedas. Por favor introduzca una cantidad válida.",
+      "null-destination-error": "La dirección nula no se puede utilizar como dirección de destino. Por favor introduzca una dirección válida.",
+      "duplicate-destination-error": "Hay destinos duplicados. Por favor no repita la misma dirección y cantidad en más de un destino.",
+      "hours-in-automatic-mode-error": "No se pueden especificar cantidades de horas mientras se usa la distribución automática de horas. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
+      "hours-allocation-mode-needed-error": "Se requiere el modo de asignación de horas. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
+      "invalid-hours-allocation-mode-error": "Modo de asignación de horas no válido. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
+      "hours-allocation-mode-not-needed-error": "El modo de asignación de horas no se puede especificar mientras se usa la distribución de horas manual. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
+      "invalid-hours-mode-error": "Método de distribución de horas no válido. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
+      "share-factor-needed-error": "Se necesita el factor de distribución de horas. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
+      "share-factor-not-needed-error": "El factor de distribución de horas no puede ser especificado mientras se usa la distribución de horas manual. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
+      "invalid-share-factor-error": "Factor de distribución de horas inv+alido. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
+      "change-equal-to-destination-error": "No es posible crear la transacción debido a que se regresaría una cantidad repetida de monedas a la misma dirección de destino. Por favor inténtelo nuevamente con valores diferentes."
+    },
+
     "bulk-send": {
       "title": "Envío Masivo",
       "indications": "Para enviar a múltiples destinos de forma rápida, escriba cada dirección, cantidad de monedas y cantidad de horas (opcional) en una línea, separadas por una coma. Ejemplo: si desea enviar 10 monedas y 5 horas a la dirección \"xyz\", escriba \"xyz,10,5\"; si desea que las horas se calculen automáticamente, escriba \"xyz,10\". Los valores decimales se deben separar con un punto.",

--- a/src/gui/static/src/assets/i18n/es_base.json
+++ b/src/gui/static/src/assets/i18n/es_base.json
@@ -261,6 +261,23 @@
     "sending-all-hours-waning": "You selected to send all the hours. Are you sure you want to continue?",
     "high-hours-share-waning": "Your selection may result in sending all the hours in the wallet. Are you sure you want to continue?",
 
+    "known-node-errors": {
+      "null-change-address-error": "The null address can't be used as the custom change address. Please enter a valid address.",
+      "to-required-error": "You must provide a destination address for sending coins. Please enter a valid address.",
+      "zero-coins-error": "It's not possible to send zero coins. Please enter a valid amount.",
+      "null-destination-error": "The null address can't be used as destination. Please enter a valid address.",
+      "duplicate-destination-error": "There are duplicate destinations. Please do not repeat the same address and amount in more than one destination.",
+      "hours-in-automatic-mode-error": "Specific hour amounts can't be specified while using automatic hour distribution. Please try with different values and contact support if the problem is not solved.",
+      "hours-allocation-mode-needed-error": "The hour allocation mode is required. Please try with different values and contact support if the problem is not solved.",
+      "invalid-hours-allocation-mode-error": "Invalid hour allocation mode. Please try with different values and contact support if the problem is not solved.",
+      "hours-allocation-mode-not-needed-error": "The hour allocation mode can't be specified while using manual hour distribution. Please try with different values and contact support if the problem is not solved.",
+      "invalid-hours-mode-error": "Invalid hour distribution method. Please try with different values and contact support if the problem is not solved.",
+      "share-factor-needed-error": "The hours share factor is needed. Please try with different values and contact support if the problem is not solved.",
+      "share-factor-not-needed-error": "The hours share factor can't be specified while using manual hour distribution. Please try with different values and contact support if the problem is not solved.",
+      "invalid-share-factor-error": "Invalid share factor. Please try with different values and contact support if the problem is not solved.",
+      "change-equal-to-destination-error": "The transaction can't be created because a repeated amount of coins would be returned to the same destination address. Please try again with different values."
+    },
+
     "bulk-send": {
       "title": "Bulk Send",
       "indications": "To send to multiple destinations in a quick way, type each address, coin amount and hour amount (optional) on a line, separated by a comma. Example: if you want to send 10 coins and 5 hours to the \"xyz\" address, type \"xyz,10,5\"; if you want the hours to be calculated automatically, type \"xyz,10\". Decimal values must be separated with a dot.",


### PR DESCRIPTION
Fixes #281 

Changes:
- The errors from https://github.com/SkycoinProject/skycoin/blob/develop/src/transaction/params.go#L37-L62 are now caught in the front end and are replaced with different translatable error messages. Also, the error message returned when the change output is repeated is caught.

Does this change need to mentioned in CHANGELOG.md?
No