### PR TITLE
Change coin hours fee to 1 percent

### DIFF
--- a/cmd/skycoin/skycoin.go
+++ b/cmd/skycoin/skycoin.go
@@ -75,10 +75,10 @@ var (
 		WebInterfacePort:    6420,
 		DataDirectory:       "$HOME/.skycoin",
 
-		UnconfirmedBurnFactor:          10,
+		UnconfirmedBurnFactor:          100,
 		UnconfirmedMaxTransactionSize:  32768,
 		UnconfirmedMaxDropletPrecision: 3,
-		CreateBlockBurnFactor:          10,
+		CreateBlockBurnFactor:          100,
 		CreateBlockMaxTransactionSize:  32768,
 		CreateBlockMaxDropletPrecision: 3,
 		MaxBlockTransactionsSize:       32768,

--- a/src/cli/integration/integration_test.go
+++ b/src/cli/integration/integration_test.go
@@ -1597,6 +1597,8 @@ func TestStableStatus(t *testing.T) {
 	var expect cli.StatusResult
 	td := TestData{ret, &expect}
 	loadGoldenFile(t, goldenFile, td)
+	fmt.Println("expect.burnFactor", expect.Status.UserVerifyTxn.BurnFactor)
+	fmt.Println("expect.burnFactor", expect.Status.UnconfirmedVerifyTxn.BurnFactor)
 
 	// The RPC port is not always the same between runs of the stable integration tests,
 	// so use the RPC_ADDR envvar instead of the golden file value for comparison

--- a/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled-no-unconfirmed.golden
+++ b/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled-no-unconfirmed.golden
@@ -33,12 +33,12 @@
 		"gui_enabled": false,
 		"block_publisher": false,
 		"user_verify_transaction": {
-			"burn_factor": 10,
+			"burn_factor": 100,
 			"max_transaction_size": 32768,
 			"max_decimals": 3
 		},
 		"unconfirmed_verify_transaction": {
-			"burn_factor": 10,
+			"burn_factor": 100,
 			"max_transaction_size": 32768,
 			"max_decimals": 3
 		},

--- a/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled.golden
+++ b/src/cli/integration/testdata/status-csrf-enabled-header-check-disabled.golden
@@ -33,12 +33,12 @@
 		"gui_enabled": false,
 		"block_publisher": false,
 		"user_verify_transaction": {
-			"burn_factor": 10,
+			"burn_factor": 100,
 			"max_transaction_size": 32768,
 			"max_decimals": 3
 		},
 		"unconfirmed_verify_transaction": {
-			"burn_factor": 10,
+			"burn_factor": 100,
 			"max_transaction_size": 32768,
 			"max_decimals": 3
 		},

--- a/src/cli/integration/testdata/status-no-unconfirmed.golden
+++ b/src/cli/integration/testdata/status-no-unconfirmed.golden
@@ -33,12 +33,12 @@
 		"gui_enabled": false,
 		"block_publisher": false,
 		"user_verify_transaction": {
-			"burn_factor": 10,
+			"burn_factor": 100,
 			"max_transaction_size": 32768,
 			"max_decimals": 3
 		},
 		"unconfirmed_verify_transaction": {
-			"burn_factor": 10,
+			"burn_factor": 100,
 			"max_transaction_size": 32768,
 			"max_decimals": 3
 		},

--- a/src/cli/integration/testdata/status.golden
+++ b/src/cli/integration/testdata/status.golden
@@ -33,12 +33,12 @@
 		"gui_enabled": false,
 		"block_publisher": false,
 		"user_verify_transaction": {
-			"burn_factor": 10,
+			"burn_factor": 100,
 			"max_transaction_size": 32768,
 			"max_decimals": 3
 		},
 		"unconfirmed_verify_transaction": {
-			"burn_factor": 10,
+			"burn_factor": 100,
 			"max_transaction_size": 32768,
 			"max_decimals": 3
 		},

--- a/src/params/params.go
+++ b/src/params/params.go
@@ -119,7 +119,7 @@ var (
 	// UserVerifyTxn transaction verification parameters for user-created transactions
 	UserVerifyTxn = VerifyTxn{
 		// BurnFactor can be overriden with `USER_BURN_FACTOR` env var
-		BurnFactor: 10,
+		BurnFactor: 100,
 		// MaxTransactionSize can be overriden with `USER_MAX_TXN_SIZE` env var
 		MaxTransactionSize: 32768, // in bytes
 		// MaxDropletPrecision can be overriden with `USER_MAX_DECIMALS` env var


### PR DESCRIPTION
Fixes #280 

Changes:
- Change the coin hour burn factor to 100 so that the coin hour fee can be 1 percent.

Does this change need to mentioned in CHANGELOG.md?
Yes.