### PR TITLE
Fix a problem with the background color

### DIFF
--- a/src/gui/static/src/app/app.component.html
+++ b/src/gui/static/src/app/app.component.html
@@ -6,8 +6,9 @@
 </div>
 <!--
   Div which is shown in the background, needed to avoid a problem which makes the background
-  color of the <body> element to be shown incorrectly in the Electron build when a modal window
-  is open and the content has been scrolled.
+  color of the <body> element to be shown incorrectly when a modal window is open and the
+  content has been scrolled. In that case, the browser window background (which may be different
+  from the document background) may replace part of the document background.
 -->
 <div class="background-fixer"></div>
 <router-outlet></router-outlet>

--- a/src/gui/static/src/app/app.component.html
+++ b/src/gui/static/src/app/app.component.html
@@ -4,5 +4,11 @@
     <div>{{ 'errors.window-size' | translate }}</div>
   </div>
 </div>
+<!--
+  Div which is shown in the background, needed to avoid a problem which makes the background
+  color of the <body> element to be shown incorrectly in the Electron build when a modal window
+  is open and the content has been scrolled.
+-->
+<div class="background-fixer"></div>
 <router-outlet></router-outlet>
 <app-msg-bar #msgBar></app-msg-bar>

--- a/src/gui/static/src/styles.scss
+++ b/src/gui/static/src/styles.scss
@@ -25,8 +25,8 @@ mat-panel-description, mat-panel-title, mat-option.mat-option {
 }
 
 // Class for the div which is shown in the background, needed to avoid a problem which makes the
-// background color of the <body> element to be shown incorrectly in the Electron build when a
-// modal window is open and the content has been scrolled.
+// background color of the <body> element to be shown incorrectly when a modal window is open
+// and the content has been scrolled.
 .background-fixer {
   background-color: $grey-lightest;
   width: 100%;

--- a/src/gui/static/src/styles.scss
+++ b/src/gui/static/src/styles.scss
@@ -24,6 +24,19 @@ mat-panel-description, mat-panel-title, mat-option.mat-option {
   font-family: $font-family;
 }
 
+// Class for the div which is shown in the background, needed to avoid a problem which makes the
+// background color of the <body> element to be shown incorrectly in the Electron build when a
+// modal window is open and the content has been scrolled.
+.background-fixer {
+  background-color: $grey-lightest;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}
+
 html {
   height: 100%;
 }


### PR DESCRIPTION
Changes:
- Using Electron, if a modal window is opened while the content has been scrolled, the background color is not shown as it should:
![background](https://user-images.githubusercontent.com/34079003/95666455-c9ab2a00-0b27-11eb-81ab-df88c4c9adb8.png)
This PR solves that problem.

Does this change need to mentioned in CHANGELOG.md?
No