### PR TITLE
Fix bip44 wallet newAddress error for existing wallet

### DIFF
--- a/src/wallet/bip44wallet/account_test.go
+++ b/src/wallet/bip44wallet/account_test.go
@@ -356,12 +356,14 @@ func requireBip44AccountEqual(t *testing.T, a, b *bip44Account) {
 	require.Equal(t, a.CoinType, b.CoinType)
 
 	require.Equal(t, len(a.Chains), len(b.Chains))
+	aDecoder := wallet.ResolveAddressDecoder(a.CoinType)
+	bDecoder := wallet.ResolveAddressDecoder(b.CoinType)
 	for j, c := range a.Chains {
 		cc := b.Chains[j]
 		require.Equal(t, c.PubKey, cc.PubKey)
 		require.Equal(t, c.ChainIndex, cc.ChainIndex)
 		// verify that the cloned addressFromPubKey func performs the same operation.
-		require.Equal(t, c.addressFromPubKey(cipher.MustNewPubKey(c.PubKey.Key)), cc.addressFromPubKey(cipher.MustNewPubKey(c.PubKey.Key)))
+		require.Equal(t, aDecoder.AddressFromPubKey(cipher.MustNewPubKey(c.PubKey.Key)), bDecoder.AddressFromPubKey(cipher.MustNewPubKey(c.PubKey.Key)))
 		require.Equal(t, len(c.Entries), len(cc.Entries))
 		for i, e := range c.Entries {
 			ce := cc.Entries[i]


### PR DESCRIPTION
Fixes:

The node reported a panic error when handling the newAddress API request for an existing bip44 wallet. It panics because the bip44 chains do not have the address decoder recovered when recovering from a readable wallet. We can fix it by init the address decoder, however that may not be a good practice for the wallet API, as users can easily forget the init of chain decoder. Instead we should force user to pass the decoder as a param when call the `newAddresses` method.


Does this change need to mentioned in CHANGELOG.md?
No