### PR TITLE
Better error msg for repeated wallets

### DIFF
--- a/src/gui/static/src/app/utils/errors.ts
+++ b/src/gui/static/src/app/utils/errors.ts
@@ -188,6 +188,8 @@ function checkIfKnownErrorStrings(errorString: string): string {
     translatableVar = 'invalid-share-factor-error';
   } else if (errorString.includes('TRANSACTION VIOLATES HARD CONSTRAINT: DUPLICATE OUTPUT IN TRANSACTION')) {
     translatableVar = 'change-equal-to-destination-error';
+  } else if (errorString.includes('FINGERPRINT CONFLICT FOR')) {
+    translatableVar = 'repeated-wallet';
   }
 
   if (translatableVar) {

--- a/src/gui/static/src/assets/i18n/en.json
+++ b/src/gui/static/src/assets/i18n/en.json
@@ -294,7 +294,8 @@
       "share-factor-needed-error": "The hours share factor is needed. Please try with different values and contact support if the problem is not solved.",
       "share-factor-not-needed-error": "The hours share factor can't be specified while using manual hour distribution. Please try with different values and contact support if the problem is not solved.",
       "invalid-share-factor-error": "Invalid share factor. Please try with different values and contact support if the problem is not solved.",
-      "change-equal-to-destination-error": "The transaction can't be created because a repeated amount of coins would be returned to the same destination address. Please try again with different values."
+      "change-equal-to-destination-error": "The transaction can't be created because a repeated amount of coins would be returned to the same destination address. Please try again with different values.",
+      "repeated-wallet": "A wallet for the specified seed already exists."
     },
 
     "bulk-send": {

--- a/src/gui/static/src/assets/i18n/es.json
+++ b/src/gui/static/src/assets/i18n/es.json
@@ -294,7 +294,8 @@
       "share-factor-needed-error": "Se necesita el factor de distribución de horas. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
       "share-factor-not-needed-error": "El factor de distribución de horas no puede ser especificado mientras se usa la distribución de horas manual. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
       "invalid-share-factor-error": "Factor de distribución de horas inv+alido. Por favor pruebe con valores diferentes y póngase en contacto con el servicio de soporte si el problema no se resuelve.",
-      "change-equal-to-destination-error": "No es posible crear la transacción debido a que se regresaría una cantidad repetida de monedas a la misma dirección de destino. Por favor inténtelo nuevamente con valores diferentes."
+      "change-equal-to-destination-error": "No es posible crear la transacción debido a que se regresaría una cantidad repetida de monedas a la misma dirección de destino. Por favor inténtelo nuevamente con valores diferentes.",
+      "repeated-wallet": "Una billetera para la semilla indicada ya existe."
     },
 
     "bulk-send": {

--- a/src/gui/static/src/assets/i18n/es_base.json
+++ b/src/gui/static/src/assets/i18n/es_base.json
@@ -294,7 +294,8 @@
       "share-factor-needed-error": "The hours share factor is needed. Please try with different values and contact support if the problem is not solved.",
       "share-factor-not-needed-error": "The hours share factor can't be specified while using manual hour distribution. Please try with different values and contact support if the problem is not solved.",
       "invalid-share-factor-error": "Invalid share factor. Please try with different values and contact support if the problem is not solved.",
-      "change-equal-to-destination-error": "The transaction can't be created because a repeated amount of coins would be returned to the same destination address. Please try again with different values."
+      "change-equal-to-destination-error": "The transaction can't be created because a repeated amount of coins would be returned to the same destination address. Please try again with different values.",
+      "repeated-wallet": "A wallet for the specified seed already exists."
     },
 
     "bulk-send": {


### PR DESCRIPTION
Changes:
- Currently, when trying to load a wallet that is already on the wallet list, the error message shown is `500 Internal Server Error - fingerprint conflict for "deterministic" wallet.`. This PR changes it to `A wallet for the specified seed already exists.`.

Does this change need to mentioned in CHANGELOG.md?
No