### PR TITLE
Remove the translation check from Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ scratch, to remedy the rough edges in the Bitcoin design.
 		- [Translations](#translations)
 	- [Releases](#releases)
 		- [Update the version](#update-the-version)
+		- [Check the translations](#check-the-translations)
 		- [Pre-release testing](#pre-release-testing)
 		- [Creating release builds](#creating-release-builds)
 		- [Release signing](#release-signing)
@@ -747,6 +748,12 @@ You can find information about how to work with translation files in the [Transl
 
 If there are problems discovered after merging to `master`, start over, and increment the 3rd version number.
 For example, `v0.20.0` becomes `v0.20.1`, for minor fixes.
+
+#### Check the translations
+
+Run `make check-lang` to check if the translation files of the UI are updated. If there is any error running
+that command, one or more translation files may need to be updated. For more information, check the
+[translations](#translations) section.
 
 #### Pre-release testing
 

--- a/ci-scripts/lint-and-test.sh
+++ b/ci-scripts/lint-and-test.sh
@@ -10,7 +10,6 @@ if [[ ${TEST_SUIT} == "units" ]]; then
     make install-linters
     make lint
     make lint-ui
-    make check-lang
     make test-386
     make test-amd64
     make test-ui


### PR DESCRIPTION
Changes:
- The procedure for checking the translation files was removed from the Travis tests. This is because the current setup requires all the translation files to be updated in order to pass the Travis test, which is inconvenient, as some PRs will include changes for the UI texts but it will not be possible to make all the translations before creating the PR. An example of this is https://github.com/SkycoinProject/skycoin/pull/303 , which includes a new string for the UI but lacks the Chinese translation.

- A section with info about checking the translation files was added to the main readme file.

Does this change need to mentioned in CHANGELOG.md?
No